### PR TITLE
Fix wrong NTT flag for dckks.RefreshProtocol output

### DIFF
--- a/dckks/transform.go
+++ b/dckks/transform.go
@@ -115,7 +115,7 @@ func (rfp *MaskedTransformProtocol) AllocateShare(levelDecrypt, levelRecrypt int
 }
 
 // SampleCRP samples a common random polynomial to be used in the Masked-Transform protocol from the provided
-// common reference string. The CRP is considered as being in the NTT domain.
+// common reference string. The CRP is considered to be in the NTT domain.
 func (rfp *MaskedTransformProtocol) SampleCRP(level int, crs utils.PRNG) drlwe.CKSCRP {
 	crp := rfp.s2e.SampleCRP(level, crs)
 	crp.IsNTT = true

--- a/dckks/transform.go
+++ b/dckks/transform.go
@@ -115,9 +115,11 @@ func (rfp *MaskedTransformProtocol) AllocateShare(levelDecrypt, levelRecrypt int
 }
 
 // SampleCRP samples a common random polynomial to be used in the Masked-Transform protocol from the provided
-// common reference string.
+// common reference string. The CRP is considered as being in the NTT domain.
 func (rfp *MaskedTransformProtocol) SampleCRP(level int, crs utils.PRNG) drlwe.CKSCRP {
-	return rfp.s2e.SampleCRP(level, crs)
+	crp := rfp.s2e.SampleCRP(level, crs)
+	crp.IsNTT = true
+	return crp
 }
 
 // GenShare generates the shares of the PermuteProtocol


### PR DESCRIPTION
The `IsNTT` flag for second polynomial of the output ciphertext of the `dckks.RefreshProtocol` is not set to true. I propose to fix that by considering the CRP as being in NTT.