### PR TITLE
fixed sparse ternary sampler to wipe poly before sampling

### DIFF
--- a/ring/ring_sampler_ternary.go
+++ b/ring/ring_sampler_ternary.go
@@ -213,6 +213,13 @@ func (ts *TernarySampler) sampleSparse(lvl int, pol *Poly) {
 			pointer = 0
 		}
 	}
+
+	for _, i := range index {
+		for k := 0; k < lvl+1; k++ {
+			pol.Coeffs[k][i] = 0
+		}
+
+	}
 }
 
 // kysampling uses the binary expansion and random bytes matrix to sample a discrete Gaussian value and its sign.

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -391,17 +391,25 @@ func testTernarySampler(testContext *testParams, t *testing.T) {
 
 			ternarySampler := NewTernarySamplerWithHammingWeight(prng, testContext.ringQ, p, false)
 
+			checkPoly := func(pol *Poly) {
+				for i := range testContext.ringQ.Modulus {
+					hw := 0
+					for _, c := range pol.Coeffs[i] {
+						if c != 0 {
+							hw++
+						}
+					}
+					require.True(t, hw == p)
+				}
+			}
+
 			pol := ternarySampler.ReadNew()
 
-			for i := range testContext.ringQ.Modulus {
-				hw := 0
-				for _, c := range pol.Coeffs[i] {
-					if c != 0 {
-						hw++
-					}
-				}
-				require.True(t, hw == p)
-			}
+			checkPoly(pol)
+
+			ternarySampler.Read(pol)
+
+			checkPoly(pol)
 		})
 	}
 }


### PR DESCRIPTION
fix correctness issue when using sparse sampler on non-empty poly