### PR TITLE
BFV - Circuit Privacy

### DIFF
--- a/bfv/bfv_test.go
+++ b/bfv/bfv_test.go
@@ -54,7 +54,7 @@ func TestBFV(t *testing.T) {
 		defaultParams = []ParametersLiteral{jsonParams} // the custom test suite reads the parameters from the -params flag
 	}
 
-	for _, p := range defaultParams {
+	for _, p := range defaultParams[:] {
 
 		params, err := NewParametersFromLiteral(p)
 		if err != nil {
@@ -454,6 +454,17 @@ func testEvaluator(testctx *testContext, t *testing.T) {
 		ciphertext1 = testctx.evaluator.MulScalarNew(ciphertext1, 37)
 		testctx.ringT.MulScalar(values1, 37, values1)
 
+		verifyTestVectors(testctx, testctx.decryptor, values1, ciphertext1, t)
+	})
+
+	t.Run(testString("Evaluator/QuantizeToLvl", testctx.params), func(t *testing.T) {
+
+		values1, _, ciphertext1 := newTestVectorsRingQ(testctx, testctx.encryptorPk, t)
+
+		testctx.evaluator.QuantizeToLvl(1, ciphertext1)
+		verifyTestVectors(testctx, testctx.decryptor, values1, ciphertext1, t)
+
+		testctx.evaluator.QuantizeToLvl(0, ciphertext1)
 		verifyTestVectors(testctx, testctx.decryptor, values1, ciphertext1, t)
 	})
 

--- a/bfv/encoder.go
+++ b/bfv/encoder.go
@@ -104,7 +104,7 @@ func NewEncoder(params Parameters) Encoder {
 	var rescaleParams []uint64
 	var scaler ring.Scaler
 	var tdividesQ bool
-	if !utils.IsInSliceUint64(params.T(), params.Q()) {
+	if params.T() != params.Q()[0] {
 		rescaleParams = make([]uint64, len(ringQ.Modulus))
 		for i, qi := range ringQ.Modulus {
 			rescaleParams[i] = ring.MForm(ring.ModExp(params.T(), qi-2, qi), qi, ringQ.BredParams[i])

--- a/bfv/encoder.go
+++ b/bfv/encoder.go
@@ -215,7 +215,7 @@ func (ecd *encoder) ScaleUp(ptRt *PlaintextRingT, pt *Plaintext) {
 
 // ScaleDown transforms a Plaintext (R_q) into a PlaintextRingT (R_t) by scaling down the coefficient by t/Q and rounding.
 func (ecd *encoder) ScaleDown(pt *Plaintext, ptRt *PlaintextRingT) {
-	ecd.scaler.DivByQOverTRounded(pt.Value, ptRt.Value)
+	ecd.scaler.DivByQOverTRoundedLvl(pt.Level(), pt.Value, ptRt.Value)
 }
 
 // RingTToMul transforms a PlaintextRingT into a PlaintextMul by operating the NTT transform

--- a/bfv/evaluator.go
+++ b/bfv/evaluator.go
@@ -136,7 +136,7 @@ func NewEvaluator(params Parameters, evaluationKey rlwe.EvaluationKey) Evaluator
 	ev.evaluatorBase = newEvaluatorPrecomp(params)
 	ev.evaluatorBuffers = newEvaluatorBuffer(ev.evaluatorBase)
 
-	if !utils.IsInSliceUint64(params.T(), params.Q()) {
+	if params.T() != params.Q()[0] {
 		ev.tInvModQ = make([]uint64, len(params.RingQ().Modulus))
 		for i, qi := range params.RingQ().Modulus {
 			ev.tInvModQ[i] = ring.MForm(ring.ModExp(params.T(), qi-2, qi), qi, params.RingQ().BredParams[i])

--- a/bfv/params.go
+++ b/bfv/params.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tuneinsight/lattigo/v3/ring"
 	"github.com/tuneinsight/lattigo/v3/rlwe"
+	"github.com/tuneinsight/lattigo/v3/utils"
 )
 
 var (
@@ -16,7 +17,7 @@ var (
 		LogN:  12,
 		T:     65537,
 		Q:     []uint64{0x7ffffec001, 0x8000016001}, // 39 + 39 bits
-		P:     []uint64{0x40002001},                 // 30 bits
+		P:     []uint64{0x40002001},                        // 30 bits
 		Sigma: rlwe.DefaultSigma,
 	}
 	// PN13QP218 is a set of default parameters with logN=13 and logQP=218
@@ -24,7 +25,7 @@ var (
 		LogN:  13,
 		T:     65537,
 		Q:     []uint64{0x3fffffffef8001, 0x4000000011c001, 0x40000000120001}, // 54 + 54 + 54 bits
-		P:     []uint64{0x7ffffffffb4001},                                     // 55 bits
+		P:     []uint64{0x7ffffffffb4001},                                            // 55 bits
 		Sigma: rlwe.DefaultSigma,
 	}
 
@@ -130,9 +131,15 @@ type Parameters struct {
 // NewParameters instantiate a set of BFV parameters from the generic RLWE parameters and the BFV-specific ones.
 // It returns the empty parameters Parameters{} and a non-nil error if the specified parameters are invalid.
 func NewParameters(rlweParams rlwe.Parameters, t uint64) (p Parameters, err error) {
+
+	if utils.IsInSliceUint64(t, rlweParams.Q()) && rlweParams.Q()[0] != t{
+		return Parameters{}, fmt.Errorf("if t|Q then Q[0] must be t")
+	}
+
 	if rlweParams.Equals(rlwe.Parameters{}) {
 		return Parameters{}, fmt.Errorf("provided RLWE parameters are invalid")
 	}
+
 	if t > rlweParams.Q()[0] {
 		return Parameters{}, fmt.Errorf("t=%d is larger than Q[0]=%d", t, rlweParams.Q()[0])
 	}

--- a/bfv/params.go
+++ b/bfv/params.go
@@ -17,7 +17,7 @@ var (
 		LogN:  12,
 		T:     65537,
 		Q:     []uint64{0x7ffffec001, 0x8000016001}, // 39 + 39 bits
-		P:     []uint64{0x40002001},                        // 30 bits
+		P:     []uint64{0x40002001},                 // 30 bits
 		Sigma: rlwe.DefaultSigma,
 	}
 	// PN13QP218 is a set of default parameters with logN=13 and logQP=218
@@ -25,7 +25,7 @@ var (
 		LogN:  13,
 		T:     65537,
 		Q:     []uint64{0x3fffffffef8001, 0x4000000011c001, 0x40000000120001}, // 54 + 54 + 54 bits
-		P:     []uint64{0x7ffffffffb4001},                                            // 55 bits
+		P:     []uint64{0x7ffffffffb4001},                                     // 55 bits
 		Sigma: rlwe.DefaultSigma,
 	}
 
@@ -132,7 +132,7 @@ type Parameters struct {
 // It returns the empty parameters Parameters{} and a non-nil error if the specified parameters are invalid.
 func NewParameters(rlweParams rlwe.Parameters, t uint64) (p Parameters, err error) {
 
-	if utils.IsInSliceUint64(t, rlweParams.Q()) && rlweParams.Q()[0] != t{
+	if utils.IsInSliceUint64(t, rlweParams.Q()) && rlweParams.Q()[0] != t {
 		return Parameters{}, fmt.Errorf("if t|Q then Q[0] must be t")
 	}
 

--- a/bfv/utils.go
+++ b/bfv/utils.go
@@ -10,11 +10,21 @@ import (
 
 // DecryptAndPrintError decrypts a ciphertext and prints the log2 of the error.
 func DecryptAndPrintError(ptWant *Plaintext, cthave *Ciphertext, ringQ *ring.Ring, decryptor Decryptor) {
-	ringQ.Sub(cthave.Value[0], ptWant.Value, cthave.Value[0])
+
+	level := cthave.Level()
+
+	ringQ.SubLvl(level, cthave.Value[0], ptWant.Value, cthave.Value[0])
 	plaintext := decryptor.DecryptNew(cthave)
+
 	bigintCoeffs := make([]*big.Int, ringQ.N)
-	ringQ.PolyToBigint(plaintext.Value, 1, bigintCoeffs)
-	center(bigintCoeffs, ringQ.ModulusBigint)
+	ringQ.PolyToBigintLvl(level, plaintext.Value, 1, bigintCoeffs)
+
+	Q := new(big.Int).SetUint64(1)
+	for i := 0; i < level+1; i++ {
+		Q.Mul(Q, new(big.Int).SetUint64(ringQ.Modulus[i]))
+	}
+
+	center(bigintCoeffs, Q)
 	stdErr, minErr, maxErr := errorStats(bigintCoeffs)
 	fmt.Printf("STD : %f - Min : %f - Max : %f\n", math.Log2(stdErr), math.Log2(minErr), math.Log2(maxErr))
 }

--- a/ring/ring_automorphism.go
+++ b/ring/ring_automorphism.go
@@ -112,9 +112,16 @@ func (r *Ring) PermuteNTTWithIndexAndAddNoModLvl(level int, polIn *Poly, index [
 }
 
 // Permute applies the Galois transform on a polynomial outside of the NTT domain.
-// It maps the coefficients x^i to x^(gen*i)
+// It maps the coefficients x^i to x^(gen*i).
 // It must be noted that the result cannot be in-place.
 func (r *Ring) Permute(polIn *Poly, gen uint64, polOut *Poly) {
+	r.PermuteLvl(utils.MinInt(polIn.Level(), polOut.Level()), polIn, gen, polOut)
+}
+
+// PermuteLvl applies the Galois transform on a polynomial outside of the NTT domain.
+// It maps the coefficients x^i to x^(gen*i).
+// It must be noted that the result cannot be in-place.
+func (r *Ring) PermuteLvl(level int, polIn *Poly, gen uint64, polOut *Poly) {
 
 	var mask, index, indexRaw, logN, tmp uint64
 
@@ -130,7 +137,7 @@ func (r *Ring) Permute(polIn *Poly, gen uint64, polOut *Poly) {
 
 		tmp = (indexRaw >> logN) & 1
 
-		for j, qi := range r.Modulus {
+		for j, qi := range r.Modulus[:level+1] {
 
 			polOut.Coeffs[j][index] = polIn.Coeffs[j][i]*(tmp^1) | (qi-polIn.Coeffs[j][i])*tmp
 		}

--- a/ring/ring_benchmark_test.go
+++ b/ring/ring_benchmark_test.go
@@ -390,7 +390,7 @@ func benchDivByRNSBasis(testContext *testParams, b *testing.B) {
 		testContext.ringQ.SetCoefficientsBigint(coeffs, polyQ)
 
 		for i := 0; i < b.N; i++ {
-			scaler.DivByQOverTRounded(polyQ, polyT)
+			scaler.DivByQOverTRoundedLvl(polyQ.Level(), polyQ, polyT)
 		}
 	})
 }

--- a/ring/ring_scaling.go
+++ b/ring/ring_scaling.go
@@ -8,7 +8,7 @@ import (
 
 // Scaler is an interface that rescales polynomial coefficients by a fraction t/Q.
 type Scaler interface {
-	// DivByQOverTRounded returns p1 scaled by a factor t/Q and mod t on the receiver p2.
+	// DivByQOverTRoundedLvl returns p1 scaled by a factor t/Q and mod t on the receiver p2.
 	DivByQOverTRoundedLvl(level int, p1, p2 *Poly)
 }
 
@@ -56,7 +56,7 @@ func NewRNSScaler(ringQ, ringT *Ring) (rnss *RNSScaler) {
 	return
 }
 
-// DivByQOverTRounded returns p1 scaled by a factor t/Q and mod t on the receiver p2.
+// DivByQOverTRoundedLvl returns p1 scaled by a factor t/Q and mod t on the receiver p2.
 func (rnss *RNSScaler) DivByQOverTRoundedLvl(level int, p1Q, p2T *Poly) {
 
 	ringQ := rnss.ringQ

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -747,7 +747,7 @@ func testScaling(testContext *testParams, t *testing.T) {
 		polyT := NewPoly(testContext.ringQ.N, 1)
 		testContext.ringQ.SetCoefficientsBigint(coeffs, polyQ)
 
-		scaler.DivByQOverTRounded(polyQ, polyT)
+		scaler.DivByQOverTRoundedLvl(polyQ.Level(), polyQ, polyT)
 
 		for i := 0; i < testContext.ringQ.N; i++ {
 			require.Equal(t, polyT.Coeffs[0][i], coeffsWant[i].Uint64())


### PR DESCRIPTION
- Enable plaintext modulus T to be a factor of Q.
- Partially introduces the concept of `levels` in BFV: a ciphertext can be rescaled, erasing the lowest bits, which can be used to enforce circuit privacy. Rescaled ciphertexts can still be operated on, but operations must be happening between ciphertexts of the same level to ensure correctness.