### PR TITLE
Improve drlwe example and documentation

### DIFF
--- a/examples/drlwe/cloud_assist_setup/main.go
+++ b/examples/drlwe/cloud_assist_setup/main.go
@@ -14,16 +14,20 @@ import (
 	"github.com/tuneinsight/lattigo/v3/utils"
 )
 
-// This example showcases the use of the drlwe package to generate an evaluation key in a multiparty setting.
-// It simulate multiple parties and their interactions within a single Go program using multiple goroutines.
-// The parties use the t-out-of-N-threshold RLWE encryption scheme as described in "An Efficient Threshold
-// Access-Structure for RLWE-Based Multiparty Homomorphic Encryption" (2022) by Mouchet, C., Bertrand, E. and
-// Hubaux, J. P. (https://eprint.iacr.org/2022/780). Moreover, this scenario showcases the use of a cloud
-// server that assists the parties in the execution of the protocol, by collecting and aggregating their public
-// shares.
+// This example showcases the use of the drlwe package to perform the multiparty HE setup phase in a cloud-assisted setting,
+// in which a third party server assists the parties in the execution of the protocol, by collecting and aggregating their public
+// shares. The MHE setup produces keys that can be used in all the BFV, BGV and CKKS scheme. The example currently demonstrate the
+// generation of the collective public key as well as a tunable number of rotation keys. The goal is to extend it to the generation
+// of the relinearization key in the future.
 //
+// The example performs the setup for a tunable threshold colluding adversarial parties. Depending on the threshold, the parties use
+// the N-out-of-N-threshold scheme described in "Multiparty Homomorphic Encryption from Ring-Learning-With-Errors"
+// (https://eprint.iacr.org/2020/304) or its t-out-of-N variant described in "An Efficient Threshold Access-Structure for RLWE-Based
+//  Multiparty Homomorphic Encryption" (https://eprint.iacr.org/2022/780).
+
+// The example simulate multiple parties and their interactions within a single Go program using multiple goroutines.
 // The scenario can be parameterized by the program arguments. Notably:
-// 	- the total number of parties,
+//  - the total number of parties,
 //  - the corruption threshold, as the number of guaranteed honest parties,
 //  - the number of parties being online to generate the evaluation key,
 //  - the parameters of the RLWE cryptosystem for which the evaluation-key is generated
@@ -34,6 +38,7 @@ import (
 
 // party represents a party in the scenario.
 type party struct {
+	*drlwe.CKGProtocol
 	*drlwe.RTGProtocol
 	*drlwe.Thresholdizer
 	*drlwe.Combiner
@@ -49,16 +54,41 @@ type party struct {
 
 // cloud represents the cloud server assisting the parties.
 type cloud struct {
+	*drlwe.CKGProtocol
 	*drlwe.RTGProtocol
 
 	aggTaskQueue chan genTaskResult
-	finDone      chan struct {
-		galEl uint64
-		rtk   rlwe.SwitchingKey
-	}
+	finDone      chan aggTaskResult
 }
 
-var crp map[uint64]drlwe.RTGCRP
+type ProtocolType int64
+
+const (
+	Invalid ProtocolType = iota
+	CKG
+	RTG
+)
+
+type genTask struct {
+	protocol  ProtocolType
+	group     []*party
+	galoisEls []uint64
+}
+
+type Share interface{}
+
+type genTaskResult struct {
+	galEl uint64
+	share Share
+}
+
+type aggTaskResult struct {
+	galEl uint64
+	key   interface{}
+}
+
+var ckgCRP drlwe.CKGCRP
+var rtgCRPs map[uint64]drlwe.RTGCRP
 
 // Run simulate the behavior of a party during the key generation protocol. The parties process
 // a queue of share-generation tasks which is attributed to them by a protocol orchestrator
@@ -85,17 +115,29 @@ func (p *party) Run(wg *sync.WaitGroup, params rlwe.Parameters, N int, P []*part
 			p.GenAdditiveShare(activePk, p.shamirPk, p.tsk, sk)
 		}
 
-		for _, galEl := range task.galoisEls {
-			rtgShare := p.AllocateShare()
-
-			p.GenShare(sk, galEl, crp[galEl], rtgShare)
-			C.aggTaskQueue <- genTaskResult{galEl: galEl, rtgShare: rtgShare}
+		switch task.protocol {
+		case CKG:
+			ckgShare := p.CKGProtocol.AllocateShare()
+			p.CKGProtocol.GenShare(sk, ckgCRP, ckgShare)
+			C.aggTaskQueue <- genTaskResult{share: ckgShare}
 			nShares++
-			byteSent += len(rtgShare.Value) * len(rtgShare.Value[0]) * rtgShare.Value[0][0].GetDataLen64(false)
+			byteSent += ckgShare.Value.GetDataLen64(false)
+		case RTG:
+			for _, galEl := range task.galoisEls {
+				rtgShare := p.RTGProtocol.AllocateShare()
+				p.RTGProtocol.GenShare(sk, galEl, rtgCRPs[galEl], rtgShare)
+				C.aggTaskQueue <- genTaskResult{galEl: galEl, share: rtgShare}
+				nShares++
+				byteSent += len(rtgShare.Value) * len(rtgShare.Value[0]) * rtgShare.Value[0][0].GetDataLen64(false)
+			}
+		default:
+			panic("invalid protocol")
 		}
+
 		nTasks++
 		cpuTime += time.Since(start)
 	}
+
 	wg.Done()
 	fmt.Printf("\tParty %d finished generating %d shares of %d tasks in %s, sent %s\n", p.i, nShares, nTasks, cpuTime, formatByteSize(byteSent))
 }
@@ -104,20 +146,28 @@ func (p *party) String() string {
 	return fmt.Sprintf("Party#%d", p.i)
 }
 
-// Run simulate the behavior of the cloud during the key generation protocol.
+// Run simulates the behavior of the cloud during the key generation protocol.
 // The cloud process aggregation requests and generates the switching keys when
 // all the parties' shares have been aggregated.
 func (c *cloud) Run(galEls []uint64, params rlwe.Parameters, t int) {
 
-	shares := make(map[uint64]*struct {
+	ckgShares := &struct {
+		share  *drlwe.CKGShare
+		needed int
+	}{
+		c.CKGProtocol.AllocateShare(),
+		t,
+	}
+
+	rtgShares := make(map[uint64]*struct {
 		share  *drlwe.RTGShare
 		needed int
 	}, len(galEls))
 	for _, galEl := range galEls {
-		shares[galEl] = &struct {
+		rtgShares[galEl] = &struct {
 			share  *drlwe.RTGShare
 			needed int
-		}{c.AllocateShare(), t}
+		}{c.RTGProtocol.AllocateShare(), t}
 	}
 
 	var i int
@@ -125,20 +175,33 @@ func (c *cloud) Run(galEls []uint64, params rlwe.Parameters, t int) {
 	var byteRecv int
 	for task := range c.aggTaskQueue {
 		start := time.Now()
-		acc := shares[task.galEl]
-		c.RTGProtocol.AggregateShares(acc.share, task.rtgShare, acc.share)
-		acc.needed--
-		if acc.needed == 0 {
-			rtk := rlwe.NewSwitchingKey(params, params.MaxLevel(), params.PCount()-1)
-			c.GenRotationKey(acc.share, crp[task.galEl], rtk)
-			c.finDone <- struct {
-				galEl uint64
-				rtk   rlwe.SwitchingKey
-			}{galEl: task.galEl, rtk: *rtk}
+
+		switch share := task.share.(type) {
+		case *drlwe.CKGShare:
+			acc := ckgShares
+			c.CKGProtocol.AggregateShares(acc.share, share, acc.share)
+			acc.needed--
+			if acc.needed == 0 {
+				cpk := rlwe.NewPublicKey(params)
+				c.GenPublicKey(acc.share, ckgCRP, cpk)
+				c.finDone <- aggTaskResult{key: *cpk}
+			}
+			byteRecv += acc.share.Value.GetDataLen64(false)
+		case *drlwe.RTGShare:
+			acc := rtgShares[task.galEl]
+			c.RTGProtocol.AggregateShares(acc.share, share, acc.share)
+			acc.needed--
+			if acc.needed == 0 {
+				rtk := rlwe.NewSwitchingKey(params, params.MaxLevel(), params.PCount()-1)
+				c.GenRotationKey(acc.share, rtgCRPs[task.galEl], rtk)
+				c.finDone <- aggTaskResult{galEl: task.galEl, key: *rtk}
+			}
+			byteRecv += len(acc.share.Value) * len(acc.share.Value[0]) * acc.share.Value[0][0].GetDataLen64(false)
+		default:
+			panic("invalid protocol")
 		}
 		i++
 		cpuTime += time.Since(start)
-		byteRecv += len(acc.share.Value) * len(acc.share.Value[0]) * acc.share.Value[0][0].GetDataLen64(false)
 	}
 	close(c.finDone)
 	fmt.Printf("\tCloud finished aggregating %d shares in %s, received %s\n", i, cpuTime, formatByteSize(byteRecv))
@@ -212,12 +275,10 @@ func main() {
 
 	wg := new(sync.WaitGroup)
 	C := &cloud{
+		CKGProtocol:  drlwe.NewCKGProtocol(params),
 		RTGProtocol:  drlwe.NewRTGProtocol(params),
 		aggTaskQueue: make(chan genTaskResult, len(galEls)*N),
-		finDone: make(chan struct {
-			galEl uint64
-			rtk   rlwe.SwitchingKey
-		}, len(galEls)),
+		finDone:      make(chan aggTaskResult, len(galEls)),
 	}
 
 	// Initialize the parties' state
@@ -227,6 +288,7 @@ func main() {
 
 	for i := range P {
 		pi := new(party)
+		pi.CKGProtocol = drlwe.NewCKGProtocol(params)
 		pi.RTGProtocol = drlwe.NewRTGProtocol(params)
 		pi.i = i
 		pi.sk = kg.GenSecretKey()
@@ -282,9 +344,10 @@ func main() {
 
 	// Sample the common random polynomials from the CRS.
 	// For the scenario, we consider it is provided as-is to the parties.
-	crp = make(map[uint64]drlwe.RTGCRP)
+	ckgCRP = P[0].CKGProtocol.SampleCRP(crs)
+	rtgCRPs = make(map[uint64]drlwe.RTGCRP)
 	for _, galEl := range galEls {
-		crp[galEl] = P[0].SampleCRP(crs)
+		rtgCRPs[galEl] = P[0].RTGProtocol.SampleCRP(crs)
 	}
 
 	// Start the cloud and the parties
@@ -298,7 +361,7 @@ func main() {
 	// distribute the key generation sub-tasks among the online parties. This
 	// simulates a protocol orchestrator affecting each party with the tasks
 	// of generating specific switching keys.
-	tasks := getTasks(galEls, groups)
+	tasks := distributeTasks(galEls, groups)
 	for _, task := range tasks {
 		for _, p := range task.group {
 			p.genTaskQueue <- task
@@ -311,45 +374,54 @@ func main() {
 	close(C.aggTaskQueue)
 
 	// collects the results
+	var cpk rlwe.PublicKey
 	rtks := make(map[uint64]rlwe.SwitchingKey)
 	for task := range C.finDone {
-		rtks[task.galEl] = task.rtk
+		switch key := task.key.(type) {
+		case rlwe.PublicKey:
+			cpk = key
+		case rlwe.SwitchingKey:
+			rtks[task.galEl] = task.key.(rlwe.SwitchingKey)
+		default:
+			panic("invalid key type")
+		}
 	}
-	fmt.Printf("Generation of %d keys completed in %s\n", len(rtks), time.Since(start))
+	fmt.Printf("Generation of 1 encryption and %d rotation keys completed in %s\n", len(rtks), time.Since(start))
 
 	fmt.Printf("Checking the keys... ")
 
 	levelQ, levelP := len(params.RingQ().Modulus)-1, len(params.RingP().Modulus)-1
 	decompSize := params.DecompPw2(levelQ, levelP) * params.DecompRNS(levelQ, levelP)
-	log2bound := bits.Len64(uint64(params.N() * decompSize * (params.N()*3*int(params.NoiseBound()) + 2*3*int(params.NoiseBound()) + params.N()*3)))
+
+	log2BoundCPK := bits.Len64(3 * params.NoiseBound() * uint64(params.N()))
+	if !rlwe.PublicKeyIsCorrect(&cpk, skIdeal, params, log2BoundCPK) {
+		fmt.Println("invalid collective encryption key")
+		os.Exit(1)
+	}
+
+	log2boundRTK := bits.Len64(uint64(params.N() * decompSize * (params.N()*3*int(params.NoiseBound()) + 2*3*int(params.NoiseBound()) + params.N()*3)))
 	for galEl, rtk := range rtks {
-		if !rlwe.RotationKeyIsCorrect(&rtk, galEl, skIdeal, params, log2bound) {
+		if !rlwe.RotationKeyIsCorrect(&rtk, galEl, skIdeal, params, log2boundRTK) {
 			fmt.Printf("invalid key for galEl=%d\n", galEl)
 			os.Exit(1)
 		}
 	}
+
 	fmt.Println("done")
 }
 
-type genTask struct {
-	group     []*party
-	galoisEls []uint64
-}
-
-type genTaskResult struct {
-	galEl uint64
-
-	rtgShare *drlwe.RTGShare
-}
-
-func getTasks(galEls []uint64, groups [][]*party) []genTask {
+func distributeTasks(galEls []uint64, groups [][]*party) []genTask {
 	tasks := make([]genTask, len(groups))
 	for i := range tasks {
+		tasks[i].protocol = RTG
 		tasks[i].group = groups[i]
 	}
 	for i, galEl := range galEls {
 		tasks[i%len(groups)].galoisEls = append(tasks[i%len(groups)].galoisEls, galEl)
 	}
+
+	tasks = append([]genTask{{protocol: CKG, group: groups[0]}}, tasks...)
+
 	return tasks
 }
 


### PR DESCRIPTION
The goal is to improve the examples and documentation of the `drlwe` package to make it clear that the MHE setup phase that it implement can be used for all schemes.

This removes the need to duplicate examples between the `dbfv` and `dckks` as pointed out in #180.
