### PR TITLE
fix latex equations

### DIFF
--- a/bfv/README.md
+++ b/bfv/README.md
@@ -56,9 +56,9 @@ on the security.
 
 The BFV scheme supports the standard recommended parameters chosen to offer a security of 128 bits
 for a secret key with uniform ternary distribution
-$s \in_u \{-1, 0, 1\}^N $, according to the [Homomorphic Encryption Standards group](https://homomorphicencryption.org/standard/).  
+$s \in_u \\{-1, 0, 1\\}^N $, according to the [Homomorphic Encryption Standards group](https://homomorphicencryption.org/standard/).  
 
-Each set of parameters is defined by the tuple $\{log_2(N), log_2(Q), \sigma \}$:
+Each set of parameters is defined by the tuple $\\{ log_2(N), log_2(Q), \sigma \\}$:
 
 - **{12, 109, 3.2}**
 - **{13, 218, 3.2}**
@@ -70,4 +70,4 @@ These parameter sets are hard-coded in the file
 variance should always be set to 3.2 unless the user is perfectly aware of the security implications
 of changing this parameter.
 
-Finally, it is worth noting that these security parameters are computed for fully entropic ternary keys (with probability distribution $\{1/3,1/3,1/3\}$ for values $\{-1,0,1\}$). Lattigo uses this fully-entropic key configuration by default. It is possible, though, to generate keys with lower entropy, by modifying their distribution to $\{(1-p)/2, p, (1-p)/2 \}$, for any $p$ between 0 and 1, which for $p\gg 1/3$ can result in low Hamming weight keys (*sparse* keys). *We recall that it has been shown that the security of sparse keys can be considerably lower than that of fully entropic keys, and the BFV security parameters should be re-evaluated if sparse keys are used*.
+Finally, it is worth noting that these security parameters are computed for fully entropic ternary keys (with probability distribution $\\{1/3,1/3,1/3\\}$ for values $\\{-1,0,1\\}$). Lattigo uses this fully-entropic key configuration by default. It is possible, though, to generate keys with lower entropy, by modifying their distribution to $\\{(1-p)/2, p, (1-p)/2 \\}$, for any $p$ between 0 and 1, which for $p\gg 1/3$ can result in low Hamming weight keys (*sparse* keys). *We recall that it has been shown that the security of sparse keys can be considerably lower than that of fully entropic keys, and the BFV security parameters should be re-evaluated if sparse keys are used*.

--- a/bfv/README.md
+++ b/bfv/README.md
@@ -5,79 +5,60 @@ scale-invariant homomorphic encryption scheme. It provides modular arithmetic ov
 
 ## Brief description
 
-This scheme can be used to do arithmetic over &nbsp;
-![equation](https://latex.codecogs.com/gif.latex?%5Cmathbb%7BZ%7D_t%5EN).
+This scheme can be used to do arithmetic over $\mathbb{Z}_t^N$.
 
 The plaintext space and the ciphertext space share the same domain
 
-<p align="center">
-<img src="https://latex.codecogs.com/gif.latex?%5Cmathbb%7BZ%7D_Q%5BX%5D/%28X%5EN%20&plus;%201%29">,
-</p>
-with <img src="https://latex.codecogs.com/gif.latex?N"> a power of 2.
+$$
+\mathbb{Z}_Q[X]/(X^N + 1)
+$$
+
+with $N$ a power of 2.
 
 The batch encoding of this scheme
 
-<p align="center">
-<img src="https://latex.codecogs.com/gif.latex?%5Cmathbb%7BZ%7D_t%5EN%20%5Cleftrightarrow%20%5Cmathbb%7BZ%7D_Q%5BX%5D/%28X%5EN%20&plus;%201%29">
-</p>
+$$
+\mathbb{Z}_t^N \leftrightarrow \mathbb{Z}_Q[X]/(X^N + 1)
+$$
 
 maps an array of integers to a polynomial with the property:
 
-<p align="center">
-<img src="https://latex.codecogs.com/gif.latex?decode%28encode%28m_1%29%20%5Cotimes%20encode%28m_2%29%29%20%3D%20m_1%20%5Codot%20m_2">,
-</p>
-where  represents &nbsp; ![equation](https://latex.codecogs.com/gif.latex?%24%5Codot%24) &nbsp; a component-wise product,and &nbsp; ![equation](https://latex.codecogs.com/gif.latex?%24%5Cotimes%24) &nbsp; represents a nega-cyclic convolution.
+$$
+decode(encode(m_1) \otimes encode(m_2)) = m_1 \odot m_2
+$$
+
+where $\odot$ represents a component-wise product, and $\otimes$ represents a nega-cyclic convolution.
 
 ## Security parameters
 
-![equation](https://latex.codecogs.com/gif.latex?N%20%3D%202%5E%7BlogN%7D): the ring dimension,
-which defines the degree of the cyclotomic polynomial, and the number of coefficients of the
-plaintext/ciphertext polynomials; it should always be a power of two. This parameter has an impact
-on both security and performance (security increases with N and performance decreases with N). It
-should be carefully chosen to suit the intended use of the scheme.
+$N = 2^{logN}$: the ring dimension,
+which defines the degree of the cyclotomic polynomial, and the number of coefficients of the plaintext/ciphertext polynomials; it should always be a power of two. This parameter has an impact on both security and performance (security increases with N and performance decreases with N). It should be carefully chosen to suit the intended use of the scheme.
 
-![equation](https://latex.codecogs.com/gif.latex?Q): the ciphertext modulus. In Lattigo, it is
-chosen to be the product of small coprime moduli
-![equation](https://latex.codecogs.com/gif.latex?q_i) that verify
-![equation](https://latex.codecogs.com/gif.latex?q_i%20%5Cequiv%201%20%5Cmod%202N) in order to
-enable both the RNS and NTT representation. The used moduli
-![equation](https://latex.codecogs.com/gif.latex?q_i) are chosen to be of size 50 to 60 bits for the
-best performance. This parameter has an impact on both security and performance (for a fixed
-![equation](https://latex.codecogs.com/gif.latex?N), a larger
-![equation](https://latex.codecogs.com/gif.latex?Q) implies both lower security and lower
-performance). It is closely related to ![equation](https://latex.codecogs.com/gif.latex?N) and
-should be chosen carefully to suit the intended use of the scheme.
+$Q$: the ciphertext modulus. In Lattigo, it is chosen to be the product of small coprime moduli $q_i$ that verify $q_i \equiv 1 \mod 2N$ in order to
+enable both the RNS and NTT representation. The used moduli $q_i$ are chosen to be of size 50 to 60 bits for the best performance. This parameter has an impact on both security and performance (for a fixed $N$, a larger $Q$ implies both lower security and lower performance). It is closely related to $N$ and should be chosen carefully to suit the intended use of the scheme.
 
-![equation](https://latex.codecogs.com/gif.latex?%5Csigma): the variance used for the error
-polynomials. This parameter is closely tied to the security of the scheme (a larger
-![equation](https://latex.codecogs.com/gif.latex?%5Csigma) implies higher security).
+$\sigma$: the variance used for the error polynomials. This parameter is closely tied to the security of the scheme (a larger $\sigma$) implies higher security).
 
 ## Other parameters
 
-![equation](https://latex.codecogs.com/gif.latex?P): the extended ciphertext modulus. This modulus
+$P$: the extended ciphertext modulus. This modulus
 is used during the multiplication, and it has no impact on the security. It is also defined as the
-product of small coprime moduli ![equation](https://latex.codecogs.com/gif.latex?p_j) and should be
-chosen such that ![equation](https://latex.codecogs.com/gif.latex?Q%5Ccdot%20P%20%3E%20Q%5E2) by a
-small margin (~20 bits). This can be done by using one more small coprime modulus than
-![equation](https://latex.codecogs.com/gif.latex?Q).
+product of small coprime moduli $p_j$ and should be
+chosen such that $Q\cdot P > Q^2$ by a small margin (~20 bits). This can be done by using one more small coprime modulus than $Q$.
 
-![equation](https://latex.codecogs.com/gif.latex?t): the plaintext modulus. This parameter defines
+$t$: the plaintext modulus. This parameter defines
 the maximum value that a plaintext coefficient can take. If a computation leads to a higher value,
 this value will be reduced modulo the plaintext modulus. It can be initialized with any value, but
-in order to enable batching, it must be prime and verify
-![equation](https://latex.codecogs.com/gif.latex?t%20%5Cequiv%201%20%5Cmod%202N). It has no impact
+in order to enable batching, it must be prime and verify $t \equiv 1 \mod 2N$. It has no impact
 on the security.
 
 ## Choosing security parameters
 
 The BFV scheme supports the standard recommended parameters chosen to offer a security of 128 bits
 for a secret key with uniform ternary distribution
-![equation](https://latex.codecogs.com/gif.latex?s%20%5Cin_u%20%5C%7B-1%2C%200%2C%201%5C%7D%5EN),
-according to the Homomorphic Encryption Standards group
-(https://homomorphicencryption.org/standard/).  
+$s \in_u \{-1, 0, 1\}^N $, according to the [Homomorphic Encryption Standards group](https://homomorphicencryption.org/standard/).  
 
-Each set of parameters is defined by the tuple
-![equation](https://latex.codecogs.com/gif.latex?%5C%7Blog_2%28N%29%2C%20log_2%28Q%29%2C%20%5Csigma%5C%7D):
+Each set of parameters is defined by the tuple $\{log_2(N), log_2(Q), \sigma \}$:
 
 - **{12, 109, 3.2}**
 - **{13, 218, 3.2}**
@@ -89,10 +70,4 @@ These parameter sets are hard-coded in the file
 variance should always be set to 3.2 unless the user is perfectly aware of the security implications
 of changing this parameter.
 
-Finally, it is worth noting that these security parameters are computed for fully entropic ternary
-keys (with probability distribution {1/3,1/3,1/3} for values {-1,0,1}). Lattigo uses this
-fully-entropic key configuration by default. It is possible, though, to generate keys with lower
-entropy, by modifying their distribution to {(1-p)/2, p, (1-p)/2}, for any p between 0 and 1, which
-for p>>1/3 can result in low Hamming weight keys (*sparse* keys). *We recall that it has been shown
-that the security of sparse keys can be considerably lower than that of fully entropic keys, and the
-BFV security parameters should be re-evaluated if sparse keys are used*.
+Finally, it is worth noting that these security parameters are computed for fully entropic ternary keys (with probability distribution $\{1/3,1/3,1/3\}$ for values $\{-1,0,1\}$). Lattigo uses this fully-entropic key configuration by default. It is possible, though, to generate keys with lower entropy, by modifying their distribution to $\{(1-p)/2, p, (1-p)/2 \}$, for any $p$ between 0 and 1, which for $p\gg 1/3$ can result in low Hamming weight keys (*sparse* keys). *We recall that it has been shown that the security of sparse keys can be considerably lower than that of fully entropic keys, and the BFV security parameters should be re-evaluated if sparse keys are used*.

--- a/ckks/README.md
+++ b/ckks/README.md
@@ -113,10 +113,10 @@ To summarize, several parameter sets can be used to evaluate a given function, a
 ## Choosing secure parameters
 
 The CKKS scheme supports the standard recommended parameters chosen to offer a security of 128 bits
-for a secret key with uniform ternary distribution $s \in_u \{-1, 0, 1\}^N)$,
+for a secret key with uniform ternary distribution $s \in_u \\{-1, 0, 1\\}^N)$,
 according to the [Homomorphic Encryption Standards group](https://homomorphicencryption.org/standard/).
 
-Each set of security parameters is defined by the tuple $\{log_2(N), log_2(Q), \sigma\}$:
+Each set of security parameters is defined by the tuple $\\{log_2(N), log_2(Q), \sigma\\}$:
 
 - **{12, 109, 3.2}**
 - **{13, 218, 3.2}**
@@ -133,4 +133,4 @@ total modulus is equal or below the above values for a given logN, the scheme wi
 security of at least 128 bits against the current best known attacks.
 
 Finally, it is worth noting that these security parameters are computed for fully entropic ternary
-keys (with probability distribution $\{1/3,1/3,1/3\}$ for values $\{-1,0,1\}$). Lattigo uses this fully-entropic key configuration by default. It is possible, though, to generate keys with lower entropy, by modifying their distribution to $\{(1-p)/2, p, (1-p)/2\}$, for any $p$ between 0 and 1, which for $p \gg 1/3$ can result in low Hamming weight keys (*sparse* keys). *We recall that it has been shown that the security of sparse keys can be considerably lower than that of fully entropic keys, and the CKKS security parameters should be re-evaluated if sparse keys are used*.
+keys (with probability distribution $\\{1/3,1/3,1/3\\}$ for values $\\{-1,0,1\\}$). Lattigo uses this fully-entropic key configuration by default. It is possible, though, to generate keys with lower entropy, by modifying their distribution to $\\{(1-p)/2, p, (1-p)/2\\}$, for any $p$ between 0 and 1, which for $p \gg 1/3$ can result in low Hamming weight keys (*sparse* keys). *We recall that it has been shown that the security of sparse keys can be considerably lower than that of fully entropic keys, and the CKKS security parameters should be re-evaluated if sparse keys are used*.

--- a/ckks/README.md
+++ b/ckks/README.md
@@ -18,64 +18,50 @@ variant supports packing of up to N plaintext real values into a single cipherte
 ## Brief description of the Standard variant
 
 This scheme can be used to do arithmetic over
-![equation](https://latex.codecogs.com/gif.latex?%5Cmathbb%7BC%7D%5E%7BN/2%7D). The plaintext space
+$\mathbb{C}^{N/2}$. The plaintext space
 and the ciphertext space share the same domain
 
-<p align="center">
-<img src="https://latex.codecogs.com/gif.latex?%5Cmathbb%7BZ%7D_Q%5BX%5D/%28X%5EN%20&plus;%201%29">,
-</p>
-with <img src="https://latex.codecogs.com/gif.latex?N"> a power of 2.
+$$
+\mathbb{Z}_Q[X]/(X^N + 1)
+$$
+
+with $N$ a power of 2.
 
 The batch encoding of this scheme
 
-<p align="center">
-<img src="https://latex.codecogs.com/gif.latex?%5Cmathbb%7BC%7D%5E%7BN/2%7D%20%5Cleftrightarrow%20Z_Q%5BX%5D/%28X%5EN%20&plus;%201%29">.
-</p>
+$$
+\mathbb{C}^{N/2} \leftrightarrow Z_Q[X]/(X^N + 1)
+$$
 
 maps an array of complex numbers to a polynomial with the property:
 
-<p align="center">
-<img src="https://latex.codecogs.com/gif.latex?decode%28encode%28m_1%29%20%5Cotimes%20encode%28m_2%29%29%20%5Capprox%20m_1%20%5Codot%20m_2">,
-</p>
-where <img src="https://latex.codecogs.com/gif.latex?%5Cotimes"> represents a component-wise product, and <img src="https://latex.codecogs.com/gif.latex?%5Codot"> represents a nega-cyclic convolution.
+$$
+decode(encode(m_1) \otimes encode(m_2)) \approx m_1 \odot m_2
+$$
+
+where $\otimes$ represents a component-wise product, and $\odot$ represents a nega-cyclic convolution.
 
 ## Security parameters
 
-![equation](https://latex.codecogs.com/gif.latex?N%20%3D%202%5E%7BlogN%7D): the ring dimension,
-which defines the degree of the cyclotomic polynomial, and the number of coefficients of the
-plaintext/ciphertext polynomials; it should always be a power of two. This parameter has an impact
-on both security and performance (security increases with N and performance decreases with N). It
+$N = 2^{logN}$: the ring dimension,
+which defines the degree of the cyclotomic polynomial, and the number of coefficients of the plaintext/ciphertext polynomials; it should always be a power of two. This parameter has an impact on both security and performance (security increases with $N$ and performance decreases with $N$). It
 should be chosen carefully to suit the intended use of the scheme.
 
-![equation](https://latex.codecogs.com/gif.latex?Q): the ciphertext modulus. In Lattigo, it is
-chosen to be the product of a chain of small coprime moduli
-![equation](https://latex.codecogs.com/gif.latex?q_i) that verify
-![equation](https://latex.codecogs.com/gif.latex?q_i%20%5Cequiv%201%20%5Cmod%202N) in order to
-enable both the RNS and NTT representation. The used moduli
-![equation](https://latex.codecogs.com/gif.latex?q_i) are chosen to be of size 30 to 60 bits for the
-best performance. This parameter has an impact on both security and performance (for a fixed
-![equation](https://latex.codecogs.com/gif.latex?N), a larger
-![equation](https://latex.codecogs.com/gif.latex?Q) implies both lower security and lower
-performance). It is closely related to ![equation](https://latex.codecogs.com/gif.latex?N) and
-should be carefully chosen to suit the intended use of the scheme.
+$Q$: the ciphertext modulus. In Lattigo, it is chosen to be the product of a chain of small coprime moduli $q_i$ that verify $q_i \equiv 1 \mod 2N$ in order to enable both the RNS and NTT representation. The used moduli $q_i$ are chosen to be of size 30 to 60 bits for the best performance. This parameter has an impact on both security and performance (for a fixed $N$, a larger $Q$ implies both lower security and lower performance). It is closely related to $N$ and should be carefully chosen to suit the intended use of the scheme.
 
-![equation](https://latex.codecogs.com/gif.latex?%5Csigma): the variance used for the error
+$\sigma$: the variance used for the error
 polynomials. This parameter is closely tied to the security of the scheme (a larger
-![equation](https://latex.codecogs.com/gif.latex?%5Csigma) implies higher security).
+$\sigma$ implies higher security).
 
 ## Other parameters
 
-![equation](https://latex.codecogs.com/gif.latex?scale): the plaintext scale. Since complex numbers
-are encoded on polynomials with integer coefficients, the original values must be scaled during the
-encoding, before being rounded to the nearest integer. The
-![equation](https://latex.codecogs.com/gif.latex?scale) parameter is the power of two by which the
-values are multiplied during the encoding. It has an impact on the precision of the output and on
-the amount of operations a fresh encryption can undergo before overflowing.
+$scale$: the plaintext scale. Since complex numbers are encoded on polynomials with integer coefficients, the original values must be scaled during the encoding, before being rounded to the nearest integer. The $scale$ parameter is the power of two by which the values are multiplied during the encoding. It has an impact on the precision of the output and on the amount of operations a fresh encryption can undergo before overflowing.
 
 ## Choosing the right parameters for a given application
 
-There are 3 application-dependent parameters: 
-- **LogN**: it determines (a) how many values can be encoded (batched) at once (maximum N/2) in one
+There are 3 application-dependent parameters:
+
+- **LogN**: it determines (a) how many values can be encoded (batched) at once (maximum $N/2$) in one
   plaintext, and (b) the maximum total modulus bit size (the product of all the moduli) for a given
   security parameter.
 - **Modulichain**: it determines how many consecutive scalar and non-scalar multiplications (the
@@ -89,28 +75,20 @@ There are 3 application-dependent parameters:
 - **Logscale**: it determines the scale of the plaintext, affecting both the precision and the
   maximum allowed depth for a given security parameter.
 
-Configuring parameters for CKKS is very application dependent, requiring a prior analysis of the
-circuit to be executed under encryption. The following example illustrates how this parametrization
-can be done, showing that it is possible to come up with different parameter sets for a given
+Configuring parameters for CKKS is very application dependent, requiring a prior analysis of the circuit to be executed under encryption. The following example illustrates how this parametrization can be done, showing that it is possible to come up with different parameter sets for a given
 circuit, each set having pros and cons.
 
-Let us define the evaluation of an arbitrary smooth function f(x) on an array of ~4000 complex
-elements contained in a square of side 2 centered at the complex origin (with values ranging between
--1-1i and 1+1i). We first need to find a good polynomial approximation for the given range. Lattigo
-provides an automatic Chebyshev approximation for any given polynomial degree, which can be used for
-this purpose (it is also possible to define a different polynomial approximation of lower degree
-with an acceptable error).
+Let us define the evaluation of an arbitrary smooth function $f(x)$ on an array of ~4000 complex elements contained in a square of side 2 centered at the complex origin (with values ranging between
+$-1-1i$ and $1+1i$). We first need to find a good polynomial approximation for the given range. Lattigo provides an automatic Chebyshev approximation for any given polynomial degree, which can be used for
+this purpose (it is also possible to define a different polynomial approximation of lower degree with an acceptable error).
 
-Let us assume that we find an approximation of degree 5, i.e., *a + bx + cx^3 + dx^5*. This function
-can be evaluated with 3 scalar multiplications, 3 additions and 3 non-scalar multiplications,
-consuming a total of 4 levels (one for the scalar multiplications and 3 for the non-scalar
-multiplications). 
+Let us assume that we find an approximation of degree 5, i.e., $a + bx + cx^3 + dx^5$. This function can be evaluated with 3 scalar multiplications, 3 additions and 3 non-scalar multiplications, consuming a total of 4 levels (one for the scalar multiplications and 3 for the non-scalar multiplications).
 
 We then need to chose a scale for the plaintext, that will influence both the bit consumption for
-the rescaling, and the precision of the computation. If we choose a scale of 2^40, we need to
+the rescaling, and the precision of the computation. If we choose a scale of $2^{40}$, we need to
 consume at least 160 bits (4 levels) during the evaluation, and we still need some bits left to
 store the final result with an acceptable precision. Let us assume that the output of the
-approximation lies always in the square between -20-20i and 20+20i; then, the final modulus must be
+approximation lies always in the square between $-20-20i$ and $20+20i$; then, the final modulus must be
 at least 5 bits larger than the final scale (to preserve the integer precision).
 
 The following parameters will work for the posed example:
@@ -122,29 +100,23 @@ The following parameters will work for the posed example:
 But it is also possible to use less levels to have ciphertexts of smaller size and, therefore, a
 faster evaluation, at the expense of less precision. This can be achieved by using a scale of 30
 bits and squeezing two multiplications in a single level, while pre-computing the last scalar
-multiplication already in the plaintext. Instead of evaluating *a + bx + cx^3 + dx^5*, we
-pre-multiply the plaintext by d^(1/5) and evaluate *a + b/(d^(1/5))x + c/(d^(3/5)) + x^5*.
+multiplication already in the plaintext. Instead of evaluating $a + bx + cx^3 + dx^5$, we pre-multiply the plaintext by $d^{(1/5)}$ and evaluate $a + b/(d^{(1/5)})x + c/(d^{(3/5)}) + x^5$.
 
 The following parameters are enough to evaluate this modified function:
 
 - **LogN** = 13
-- **Modulichain** = [35, 60, 60], for a logQ <= 155
+- **Modulichain** = [35, 60, 60], for a $logQ \leq 155$
 - **LogScale** = 30
 
-To summarize, several parameter sets can be used to evaluate a given function, achieving different
-trade-offs for space and time versus precision.
+To summarize, several parameter sets can be used to evaluate a given function, achieving different trade-offs for space and time versus precision.
 
 ## Choosing secure parameters
 
 The CKKS scheme supports the standard recommended parameters chosen to offer a security of 128 bits
-for a secret key with uniform ternary distribution
-![equation](https://latex.codecogs.com/gif.latex?s%20%5Cin_u%20%5C%7B-1%2C%200%2C%201%5C%7D%5EN),
-according to the Homomorphic Encryption Standards group
-(https://homomorphicencryption.org/standard/).
+for a secret key with uniform ternary distribution $s \in_u \{-1, 0, 1\}^N)$,
+according to the [Homomorphic Encryption Standards group](https://homomorphicencryption.org/standard/).
 
-Each set of security parameters is defined by the tuple
-![equation](https://latex.codecogs.com/gif.latex?%5C%7Blog_2%28N%29%2C%20log_2%28Q%29%2C%20%5Csigma%5C%7D)
-:
+Each set of security parameters is defined by the tuple $\{log_2(N), log_2(Q), \sigma\}$:
 
 - **{12, 109, 3.2}**
 - **{13, 218, 3.2}**
@@ -161,9 +133,4 @@ total modulus is equal or below the above values for a given logN, the scheme wi
 security of at least 128 bits against the current best known attacks.
 
 Finally, it is worth noting that these security parameters are computed for fully entropic ternary
-keys (with probability distribution {1/3,1/3,1/3} for values {-1,0,1}). Lattigo uses this
-fully-entropic key configuration by default. It is possible, though, to generate keys with lower
-entropy, by modifying their distribution to {(1-p)/2, p, (1-p)/2}, for any p between 0 and 1, which
-for p>>1/3 can result in low Hamming weight keys (*sparse* keys). *We recall that it has been shown
-that the security of sparse keys can be considerably lower than that of fully entropic keys, and the
-CKKS security parameters should be re-evaluated if sparse keys are used*.
+keys (with probability distribution $\{1/3,1/3,1/3\}$ for values $\{-1,0,1\}$). Lattigo uses this fully-entropic key configuration by default. It is possible, though, to generate keys with lower entropy, by modifying their distribution to $\{(1-p)/2, p, (1-p)/2\}$, for any $p$ between 0 and 1, which for $p \gg 1/3$ can result in low Hamming weight keys (*sparse* keys). *We recall that it has been shown that the security of sparse keys can be considerably lower than that of fully entropic keys, and the CKKS security parameters should be re-evaluated if sparse keys are used*.


### PR DESCRIPTION
When reading the documentation I noticed that the LaTeX equations where broken or hard to read. This PR rewrites them so they can be rendered by GitHub directly instead of being loaded as raster images.

The PR could also serve as a good start to address #276 and any other inconsistencies.