### PR TITLE
fixes #427

### DIFF
--- a/mhe/mhe_test.go
+++ b/mhe/mhe_test.go
@@ -571,6 +571,6 @@ func testRefreshShare(tc *testContext, levelQ, levelP, bpw2 int, t *testing.T) {
 		share2 := cksp.AllocateShare(levelQ)
 		cksp.GenShare(tc.skShares[0], tc.skShares[1], ciphertext, &share1)
 		cksp.GenShare(tc.skShares[1], tc.skShares[0], ciphertext, &share2)
-		buffer.RequireSerializerCorrect(t, &RefreshShare{EncToShareShare: share1, ShareToEncShare: share2})
+		buffer.RequireSerializerCorrect(t, &RefreshShare{EncToShareShare: share1, ShareToEncShare: share2, MetaData: *ciphertext.MetaData})
 	})
 }

--- a/mhe/mhefloat/transform.go
+++ b/mhe/mhefloat/transform.go
@@ -187,6 +187,9 @@ func (mltp MaskedLinearTransformationProtocol) GenShare(skIn, skOut *rlwe.Secret
 		return
 	}
 
+	// Stores the metadata of the ciphertext
+	shareOut.MetaData = *ct.MetaData
+
 	// Returns [-a*s_i + LT(M_i) * diffscale + e] on ShareToEncShare
 	return mltp.s2e.GenShare(skOut, crs, ct.MetaData, mhe.AdditiveShareBigint{Value: mask}, &shareOut.ShareToEncShare)
 }
@@ -214,6 +217,10 @@ func (mltp MaskedLinearTransformationProtocol) Transform(ct *rlwe.Ciphertext, tr
 
 	if ct.Level() < share.EncToShareShare.Value.Level() {
 		return fmt.Errorf("cannot Transform: input ciphertext level must be at least equal to e2s level")
+	}
+
+	if !ct.MetaData.Equal(&share.MetaData) {
+		return fmt.Errorf("cannot Transform: input ciphertext MetaData is not equal to share.MetaData")
 	}
 
 	maxLevel := crs.Value.Level()

--- a/mhe/mheint/mheint_benchmark_test.go
+++ b/mhe/mheint/mheint_benchmark_test.go
@@ -74,7 +74,7 @@ func benchRefresh(tc *testContext, b *testing.B) {
 	b.Run(GetTestName("Refresh/Round1/Gen", tc.params, tc.NParties), func(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
-			p.GenShare(p.s, ciphertext, ciphertext.Scale, crp, &p.share)
+			p.GenShare(p.s, ciphertext, crp, &p.share)
 		}
 	})
 

--- a/mhe/mheint/mheint_test.go
+++ b/mhe/mheint/mheint_test.go
@@ -279,7 +279,7 @@ func testRefresh(tc *testContext, t *testing.T) {
 		ciphertext.Resize(ciphertext.Degree(), minLevel)
 
 		for i, p := range RefreshParties {
-			p.GenShare(p.s, ciphertext, ciphertext.Scale, crp, &p.share)
+			p.GenShare(p.s, ciphertext, crp, &p.share)
 			if i > 0 {
 				P0.AggregateShares(p.share, P0.share, &P0.share)
 			}
@@ -362,7 +362,7 @@ func testRefreshAndPermutation(tc *testContext, t *testing.T) {
 		}
 
 		for i, p := range RefreshParties {
-			p.GenShare(p.s, p.s, ciphertext, ciphertext.Scale, crp, maskedTransform, &p.share)
+			p.GenShare(p.s, p.s, ciphertext, crp, maskedTransform, &p.share)
 			if i > 0 {
 				P0.AggregateShares(P0.share, p.share, &P0.share)
 			}
@@ -464,7 +464,7 @@ func testRefreshAndTransformSwitchParams(tc *testContext, t *testing.T) {
 		}
 
 		for i, p := range RefreshParties {
-			p.GenShare(p.sIn, p.sOut, ciphertext, ciphertext.Scale, crp, transform, &p.share)
+			p.GenShare(p.sIn, p.sOut, ciphertext, crp, transform, &p.share)
 			if i > 0 {
 				P0.AggregateShares(P0.share, p.share, &P0.share)
 			}

--- a/mhe/mheint/refresh.go
+++ b/mhe/mheint/refresh.go
@@ -35,8 +35,8 @@ func (rfp RefreshProtocol) AllocateShare(inputLevel, outputLevel int) mhe.Refres
 
 // GenShare generates a share for the Refresh protocol.
 // ct1 is degree 1 element of a rlwe.Ciphertext, i.e. rlwe.Ciphertext.Value[1].
-func (rfp RefreshProtocol) GenShare(sk *rlwe.SecretKey, ct *rlwe.Ciphertext, scale rlwe.Scale, crp mhe.KeySwitchCRP, shareOut *mhe.RefreshShare) (err error) {
-	return rfp.MaskedTransformProtocol.GenShare(sk, sk, ct, scale, crp, nil, shareOut)
+func (rfp RefreshProtocol) GenShare(sk *rlwe.SecretKey, ct *rlwe.Ciphertext, crp mhe.KeySwitchCRP, shareOut *mhe.RefreshShare) (err error) {
+	return rfp.MaskedTransformProtocol.GenShare(sk, sk, ct, crp, nil, shareOut)
 }
 
 // AggregateShares aggregates two parties' shares in the Refresh protocol.


### PR DESCRIPTION
- Updates the unmarshalling of the scaling factor to not truncate the values, this was previously done to avoid the allocation of two mantissa which would cause an error in the marshalling test as the default number of mantissa of big.Float is one even if the precision is greater that 64 bits
- Updates the allocation of the scaling factor to force the allocation of two mantissas so that the marshalling does not return an error when comparing the big.Float of a freshly allocated scale
- Updates the refresh of mhe[int/float] to check that the metadata of the ciphertext that is being refreshed is the same as the one of the ciphertext that was used to generate the shares
- Updates the API of mheint refresh that had redundancy (scale was given as input but is already given by the ciphertext metadata)