### PR TITLE
[rlwe]: added .N() and .LogN() to rlwe.Element

### DIFF
--- a/core/rlwe/element.go
+++ b/core/rlwe/element.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"math/bits"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tuneinsight/lattigo/v5/ring"
@@ -15,6 +16,8 @@ import (
 
 // ElementInterface is a common interface for Ciphertext and Plaintext types.
 type ElementInterface[T ring.Poly | ringqp.Poly] interface {
+	N() int
+	LogN() int
 	El() *Element[T]
 	Degree() int
 	Level() int
@@ -87,6 +90,24 @@ func NewElementAtLevelFromPoly(level int, poly []ring.Poly) (*Element[ring.Poly]
 	}
 
 	return &Element[ring.Poly]{Value: Value}, nil
+}
+
+// N returns the ring degree of the target element.
+func (op Element[T]) N() int {
+	switch el := any(op.Value[0]).(type) {
+	case ring.Poly:
+		return el.N()
+	case ringqp.Poly:
+		return el.Q.N()
+	default:
+		// Sanity check
+		panic("invalid Element[type]")
+	}
+}
+
+// LogN returns the base 2 logarithm of the ring degree of the target element.
+func (op Element[T]) LogN() int {
+	return bits.Len64(uint64(op.N() - 1))
 }
 
 // Equal performs a deep equal.

--- a/core/rlwe/rlwe_test.go
+++ b/core/rlwe/rlwe_test.go
@@ -190,6 +190,12 @@ func testParameters(tc *TestContext, t *testing.T) {
 			require.Equal(t, uint64(1), res)
 		}
 	})
+
+	t.Run(testString(params, params.MaxLevelQ(), params.MaxLevelP(), 0, "Elements"), func(t *testing.T) {
+		ct := NewCiphertext(params, 1, 0)
+		require.Equal(t, ct.N(), params.N())
+		require.Equal(t, ct.LogN(), params.LogN())
+	})
 }
 
 func testKeyGenerator(tc *TestContext, bpw2 int, t *testing.T) {


### PR DESCRIPTION
This PR adds the methods `.N()` and `.LogN` to the `rlwe.Element`. 

This is a quality of life change that has two purposes:
- Enables the user to get an easy access to the value of ring degree or its base 2 logarithm directly from `rlwe.Ciphertext` or `rlwe.Plaintexts`. It is possible to already get these values by for example calling `bits.Len64(uint64(len(ct.Value[0].Coeffs[0]) - 1))`, however only experienced users will know that this is possible.
- Additionally, this improves code readability by replacing code such as `bits.Len64(uint64(len(ct.Value[0].Coeffs[0]) - 1))` by `ct.LogN()`.

Such information is for example needed when dealing with multiple parameter sets of different ring degree to be able to properly process an input ciphertext.