### PR TITLE
Bugfixes April 2024

### DIFF
--- a/core/rlwe/params.go
+++ b/core/rlwe/params.go
@@ -470,7 +470,7 @@ func (p Parameters) LogP() (logp float64) {
 
 // LogPi returns the round(log2) of each primes of the modulus P.
 func (p Parameters) LogPi() (logpi []int) {
-	pi := p.Q()
+	pi := p.P()
 	logpi = make([]int, len(pi))
 	for i := range pi {
 		logpi[i] = int(math.Round(math.Log2(float64(pi[i]))))

--- a/core/rlwe/scale.go
+++ b/core/rlwe/scale.go
@@ -183,6 +183,11 @@ func (s Scale) UnmarshalBinary(p []byte) (err error) {
 
 // MarshalJSON encodes the object into a binary form on a newly allocated slice of bytes.
 func (s Scale) MarshalJSON() (p []byte, err error) {
+	// reject values > 2^100
+	bound, _ := new(big.Int).SetString("10000000000000000000000000", 16)
+	if s.Value.Cmp(new(big.Float).SetInt(bound)) >= 0 {
+		return nil, fmt.Errorf("unable to marshal Scale.Value >= 2^100")
+	}
 
 	var mod string
 


### PR DESCRIPTION
This PR bundles various bugfixes for April 2024.

#449 (38e3c5f): Fix typo in the `Parameters.LogPi()` function.
#454 (1532dc9): Add `io.Writer` and `io.Reader` interfaces to the `Parameters` struct.
#453 (a1de0c5): Do not overly large `Scale` values.