### PR TITLE
Add Go v1.22 to the CI tests and update `staticcheck`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21.1'
+        go-version: '1.22.2'
 
     - uses: actions/cache@v3
       with:
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.21.1', '1.20.8', '1.19.13', '1.18.10']
+        go: ['1.22.2', '1.21.9', '1.20.14', '1.19.13', '1.18.10']
 
     steps:
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ static_check: check_tools
 		false;\
     fi
 	
-	@STATICCHECKOUT=$$(staticcheck -go 1.20 -checks all ./...); \
+	@STATICCHECKOUT=$$(staticcheck -go 1.22 -checks all ./...); \
 	if [ -z "$$STATICCHECKOUT" ]; then\
         echo "staticcheck: OK";\
 	else \
@@ -57,7 +57,7 @@ EXECUTABLES = goimports staticcheck
 .PHONY: get_tools
 get_tools:
 	go install golang.org/x/tools/cmd/goimports@latest
-	go install honnef.co/go/tools/cmd/staticcheck@2023.1.5
+	go install honnef.co/go/tools/cmd/staticcheck@2023.1.7
 
 .PHONY: check_tools
 check_tools:


### PR DESCRIPTION
Go v1.22 was released in Feb. 2024, this updates the tests showing that lattigo seem compatible.