### PR TITLE
Bugfixes May 2024 (Part 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.22.2', '1.21.9', '1.20.14', '1.19.13', '1.18.10']
+        go: ['1.22.2', '1.21.9']
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 # Changelog
 All notable changes to this library are documented in this file.
 
-## UNRELEASED [5.0.0] - 15.11.2023
+## UNRELEASED
+- Deprecated Go versions `1.18`, `1.19` and `1.20`. The minimum version is now `1.21`, due to the use of the slices of std library package.
+
+## [5.0.0] - 15.11.2023
 - Deprecated Go versions `1.14`, `1.15`, `1.16`, and `1.17`. The minimum version is now `1.18`, due to the required use of generics.
 - Golang Security Checker pass.
 - Dereferenced most inputs and pointers methods whenever possible. Pointers methods/inputs are now mostly used when the struct implementing the method and/or the input is intended to be modified.

--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ External pull requests only proposing small or trivial changes will be converted
 External contributions will require the signature of a Contributor License Agreement (CLA).
 You can contact us using the following email to request a copy of the CLA: [lattigo@tuneinsight.com](mailto:lattigo@tuneinsight.com).
 
+## Bug Reports
+
+Lattigo welcomes bug/regression reports of any kind that conform to the preset template, which is
+automatically generated upon creation of a new empty issue. Nonconformity will result in the issue
+being closed without acknowledgement.
+
 
 ## License
 

--- a/core/rlwe/gadgetciphertext.go
+++ b/core/rlwe/gadgetciphertext.go
@@ -4,11 +4,11 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"slices"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tuneinsight/lattigo/v5/ring"
 	"github.com/tuneinsight/lattigo/v5/ring/ringqp"
-	"github.com/tuneinsight/lattigo/v5/utils"
 	"github.com/tuneinsight/lattigo/v5/utils/buffer"
 	"github.com/tuneinsight/lattigo/v5/utils/structs"
 )
@@ -191,7 +191,7 @@ func AddPolyTimesGadgetVectorToGadgetCiphertext(pt ring.Poly, cts []GadgetCipher
 	N := ringQ.N()
 
 	var index int
-	for j := 0; j < utils.MaxSlice(BaseTwoDecompositionVectorSize); j++ {
+	for j := 0; j < slices.Max(BaseTwoDecompositionVectorSize); j++ {
 
 		for i := 0; i < BaseRNSDecompositionVectorSize; i++ {
 
@@ -245,7 +245,7 @@ func NewGadgetPlaintext(params Parameters, value interface{}, levelQ, levelP, ba
 
 	ringQ := params.RingQP().RingQ.AtLevel(levelQ)
 
-	BaseTwoDecompositionVectorSize := utils.MaxSlice(params.BaseTwoDecompositionVectorSize(levelQ, levelP, baseTwoDecomposition))
+	BaseTwoDecompositionVectorSize := slices.Max(params.BaseTwoDecompositionVectorSize(levelQ, levelP, baseTwoDecomposition))
 
 	pt = new(GadgetPlaintext)
 	pt.Value = make([]ring.Poly, BaseTwoDecompositionVectorSize)

--- a/core/rlwe/params.go
+++ b/core/rlwe/params.go
@@ -183,10 +183,11 @@ func NewParametersFromLiteral(paramDef ParametersLiteral) (params Parameters, er
 		paramDef.DefaultScale = s
 	}
 
+	// only allow either (Q or P) or (logQ or logP), do not mix log with non-log
 	switch {
-	case paramDef.Q != nil && paramDef.LogQ == nil:
+	case paramDef.Q != nil && paramDef.LogQ == nil && paramDef.LogP == nil:
 		return NewParameters(paramDef.LogN, paramDef.Q, paramDef.P, paramDef.Xs, paramDef.Xe, paramDef.RingType, paramDef.DefaultScale, paramDef.NTTFlag)
-	case paramDef.LogQ != nil && paramDef.Q == nil:
+	case paramDef.LogQ != nil && paramDef.Q == nil && paramDef.P == nil:
 		var q, p []uint64
 		switch paramDef.RingType {
 		case ring.Standard:

--- a/core/rlwe/scale.go
+++ b/core/rlwe/scale.go
@@ -165,9 +165,10 @@ func (s Scale) Min(s1 Scale) (max Scale) {
 }
 
 // BinarySize returns the serialized size of the object in bytes.
-// Each value is encoded with .Text('x', ceil(ScalePrecision / log2(10))).
+// Each value is encoded with .Text('e', ceil(ScalePrecision / log2(10))).
 func (s Scale) BinarySize() int {
-	return 21 + (ScalePrecisionLog10+6)<<1 // 21 for JSON formatting and 2*(8 + ScalePrecisionLog10)
+	// 21 for JSON formatting plus 2*(6 + ScalePrecisionLog10) for the scales encoding.
+	return 21 + (ScalePrecisionLog10+6)<<1
 }
 
 // MarshalBinary encodes the object into a binary form on a newly allocated slice of bytes.

--- a/core/rlwe/utils.go
+++ b/core/rlwe/utils.go
@@ -45,7 +45,7 @@ func NoiseGaloisKey(gk *GaloisKey, sk *SecretKey, params Parameters) float64 {
 	return NoiseEvaluationKey(&gk.EvaluationKey, skIn, skOut, params)
 }
 
-// NoiseGadgetCiphertext returns the log2 of the standard devaition of the noise of the input gadget ciphertext with respect to the given plaintext, secret-key and parameters.
+// NoiseGadgetCiphertext returns the log2 of the standard deviation of the noise of the input gadget ciphertext with respect to the given plaintext, secret-key and parameters.
 // The polynomial pt is expected to be in the NTT and Montgomery domain.
 func NoiseGadgetCiphertext(gct *GadgetCiphertext, pt ring.Poly, sk *SecretKey, params Parameters) float64 {
 

--- a/core/rlwe/utils.go
+++ b/core/rlwe/utils.go
@@ -3,6 +3,7 @@ package rlwe
 import (
 	"math"
 	"math/big"
+	"slices"
 
 	"github.com/tuneinsight/lattigo/v5/ring"
 	"github.com/tuneinsight/lattigo/v5/utils"
@@ -54,7 +55,7 @@ func NoiseGadgetCiphertext(gct *GadgetCiphertext, pt ring.Poly, sk *SecretKey, p
 	levelQ, levelP := gct.LevelQ(), gct.LevelP()
 	ringQP := params.RingQP().AtLevel(levelQ, levelP)
 	ringQ, ringP := ringQP.RingQ, ringQP.RingP
-	BaseTwoDecompositionVectorSize := utils.MinSlice(gct.BaseTwoDecompositionVectorSize()) // required else the check becomes very complicated
+	BaseTwoDecompositionVectorSize := slices.Min(gct.BaseTwoDecompositionVectorSize()) // required else the check becomes very complicated
 
 	// Decrypts
 	// [-asIn + w*P*sOut + e, a] + [asIn]

--- a/examples/single_party/applications/reals_bootstrapping/slim/main.go
+++ b/examples/single_party/applications/reals_bootstrapping/slim/main.go
@@ -202,7 +202,7 @@ func main() {
 		panic(err)
 	}
 
-	// Generate a random plaintext with values uniformely distributed in [-1, 1] for the real and imaginary part.
+	// Generate a random plaintext with values uniformly distributed in [-1, 1] for the real and imaginary part.
 	valuesWant := make([]complex128, params.MaxSlots())
 	for i := range valuesWant {
 		valuesWant[i] = sampling.RandComplex128(-1, 1)
@@ -235,7 +235,7 @@ func main() {
 	}
 
 	// Step 2: Some circuit in the coefficient domain
-	// Note: the result of SlotsToCoeffs is naturaly given in bit-reversed order
+	// Note: the result of SlotsToCoeffs is naturally given in bit-reversed order
 	// In this example, we multiply by the monomial X^{N/2} (which is the imaginary
 	// unit in the slots domain)
 	if err = eval.Evaluator.Mul(ciphertext, 1i, ciphertext); err != nil {

--- a/examples/single_party/templates/int/main.go
+++ b/examples/single_party/templates/int/main.go
@@ -4,10 +4,10 @@ package main
 import (
 	"fmt"
 	"math/rand"
+	"slices"
 
 	"github.com/tuneinsight/lattigo/v5/core/rlwe"
 	"github.com/tuneinsight/lattigo/v5/he/heint"
-	"github.com/tuneinsight/lattigo/v5/utils"
 )
 
 func main() {
@@ -105,7 +105,7 @@ func PrintPrecisionStats(params heint.Parameters, ct *rlwe.Ciphertext, want []ui
 	}
 	fmt.Printf("...\n")
 
-	if !utils.EqualSlice(want, have) {
+	if !slices.Equal(want, have) {
 		panic("wrong result: bad decryption or encrypted/plaintext circuits do not match")
 	}
 }

--- a/examples/single_party/tutorials/reals/main.go
+++ b/examples/single_party/tutorials/reals/main.go
@@ -50,11 +50,12 @@ func main() {
 	//
 	// Both contain the `rlwe.MetaData` struct, which notably holds the following fields:
 	//    - `Scale`: the scaling factor. This field is updated dynamically during computations.
-	//    - `EncodingDomain`:
-	//        - `SlotsDomain`: the usual encoding that provides SIMD operations over the slots.
-	//        - `CoefficientDomain`: plain encoding in the RING. Addition behaves as usual, but multiplication will result in negacyclic convolution over the slots.
-	//    - `LogSlots`: the log2 of the number of slots. Note that if a ciphertext with n slots is multiplied with a ciphertext of 2n slots, the resulting ciphertext
-	//                  will have 2n slots. Because a message `m` of n slots is identical to the message `m|m` of 2n slots.
+	//    - `IsBatched`:
+	//        - `true (slot encoding)`: the usual encoding that provides SIMD operations over the slots.
+	//        - `false (coefficient encoding)`: plain encoding in the RING. Addition behaves as usual, but multiplication will result in negacyclic convolution over the slots.
+	//    - `LogDimensions`: the log2 of the plaintext/ciphertext matrix dimension (columns, rows) with the total number of available slots being columns*rows.
+	//        Note that if a ciphertext with n slots is multiplied with a ciphertext of 2n slots, the resulting ciphertext will have 2n slots.
+	//        Because a message `m` of n slots is identical to the message `m|m` of 2n slots.
 	//
 	// These are all public fields which can be manually edited by advanced users if needed.
 	//
@@ -188,8 +189,8 @@ func main() {
 	// We can allocate plaintexts at lower levels to optimize memory consumption for operations that we know will happen at a lower level.
 	// Plaintexts (and ciphertexts) are by default created with the following metadata:
 	//   - `Scale`: `params.DefaultScale()` (which is 2^{45} in this example)
-	//   - `EncodingDomain`: `rlwe.SlotsDomain` (this is the default value)
-	//   - `LogSlots`: `params.MaxLogSlots` (which is LogN-1=13 in this example)
+	//   - `IsBatched`: `true` (this is the default value)
+	//   - `LogDimensions`: `{0, params.MaxLogSlots}` (params.MaxLogSlots = LogN-1=13 in this example)
 	// We can check that the plaintext was created at the maximum level with pt1.Level().
 	pt1 := hefloat.NewPlaintext(params, params.MaxLevel())
 
@@ -202,7 +203,7 @@ func main() {
 
 	// And we encode our `values` on the plaintext.
 	// Note that the encoder will check the metadata of the plaintext and adapt the encoding accordingly.
-	// For example, one can modify the `Scale`, `EncodingDomain` or `LogSlots` fields change the way the encoding behaves.
+	// For example, one can modify the `Scale`, `IsBatched` or `LogDimensions` fields change the way the encoding behaves.
 	if err = ecd2.Encode(values1, pt1); err != nil {
 		panic(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tuneinsight/lattigo/v5
 
-go 1.18
+go 1.21
 
 require (
 	github.com/google/go-cmp v0.5.8

--- a/he/hefloat/dft.go
+++ b/he/hefloat/dft.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"slices"
 
 	"github.com/tuneinsight/lattigo/v5/core/rlwe"
 	"github.com/tuneinsight/lattigo/v5/he"
@@ -501,7 +502,7 @@ func addMatrixRotToList(pVec map[int]bool, rotations []int, N1, slots int, repac
 
 	if len(pVec) < 3 {
 		for j := range pVec {
-			if !utils.IsInSlice(j, rotations) {
+			if !slices.Contains(rotations, j) {
 				rotations = append(rotations, j)
 			}
 		}
@@ -519,13 +520,13 @@ func addMatrixRotToList(pVec map[int]bool, rotations []int, N1, slots int, repac
 				index &= (slots - 1)
 			}
 
-			if index != 0 && !utils.IsInSlice(index, rotations) {
+			if index != 0 && !slices.Contains(rotations, index) {
 				rotations = append(rotations, index)
 			}
 
 			index = j & (N1 - 1)
 
-			if index != 0 && !utils.IsInSlice(index, rotations) {
+			if index != 0 && !slices.Contains(rotations, index) {
 				rotations = append(rotations, index)
 			}
 		}

--- a/he/heint/heint_test.go
+++ b/he/heint/heint_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"math/big"
 	"runtime"
+	"slices"
 	"testing"
 
 	"github.com/tuneinsight/lattigo/v5/core/rlwe"
@@ -167,7 +168,7 @@ func verifyTestVectors(tc *testContext, decryptor *rlwe.Decryptor, coeffs ring.P
 		t.Error("invalid test object to verify")
 	}
 
-	require.True(t, utils.EqualSlice(coeffs.Coeffs[0], coeffsTest))
+	require.True(t, slices.Equal(coeffs.Coeffs[0], coeffsTest))
 }
 
 func testLinearTransformation(tc *testContext, t *testing.T) {

--- a/mhe/keygen_evk.go
+++ b/mhe/keygen_evk.go
@@ -3,6 +3,7 @@ package mhe
 import (
 	"fmt"
 	"io"
+	"slices"
 
 	"github.com/tuneinsight/lattigo/v5/core/rlwe"
 	"github.com/tuneinsight/lattigo/v5/ring"
@@ -128,7 +129,7 @@ func (evkg EvaluationKeyGenProtocol) GenShare(skIn, skOut *rlwe.SecretKey, crp E
 		return fmt.Errorf("cannot GenShare: crp.BaseRNSDecompositionVectorSize() != shareOut.BaseRNSDecompositionVectorSize()")
 	}
 
-	if !utils.EqualSlice(shareOut.BaseTwoDecompositionVectorSize(), crp.BaseTwoDecompositionVectorSize()) {
+	if !slices.Equal(shareOut.BaseTwoDecompositionVectorSize(), crp.BaseTwoDecompositionVectorSize()) {
 		return fmt.Errorf("cannot GenShare: crp.BaseTwoDecompositionVectorSize() != shareOut.BaseTwoDecompositionVectorSize()")
 	}
 
@@ -157,7 +158,7 @@ func (evkg EvaluationKeyGenProtocol) GenShare(skIn, skOut *rlwe.SecretKey, crp E
 
 	var index int
 
-	for j := 0; j < utils.MaxSlice(BaseTwoDecompositionVectorSize); j++ {
+	for j := 0; j < slices.Max(BaseTwoDecompositionVectorSize); j++ {
 
 		for i := 0; i < BaseRNSDecompositionVectorSize; i++ {
 

--- a/mhe/keygen_relin.go
+++ b/mhe/keygen_relin.go
@@ -2,11 +2,11 @@ package mhe
 
 import (
 	"io"
+	"slices"
 
 	"github.com/tuneinsight/lattigo/v5/core/rlwe"
 	"github.com/tuneinsight/lattigo/v5/ring"
 	"github.com/tuneinsight/lattigo/v5/ring/ringqp"
-	"github.com/tuneinsight/lattigo/v5/utils"
 	"github.com/tuneinsight/lattigo/v5/utils/sampling"
 	"github.com/tuneinsight/lattigo/v5/utils/structs"
 )
@@ -168,7 +168,7 @@ func (ekg RelinearizationKeyGenProtocol) GenShareRoundOne(sk *rlwe.SecretKey, cr
 	sampler := ekg.gaussianSamplerQ.AtLevel(levelQ)
 
 	var index int
-	for j := 0; j < utils.MaxSlice(BaseTwoDecompositionVectorSize); j++ {
+	for j := 0; j < slices.Max(BaseTwoDecompositionVectorSize); j++ {
 		for i := 0; i < BaseRNSDecompositionVectorSize; i++ {
 
 			if j < BaseTwoDecompositionVectorSize[i] {

--- a/mhe/mheint/mheint_test.go
+++ b/mhe/mheint/mheint_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"runtime"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,7 +15,6 @@ import (
 	"github.com/tuneinsight/lattigo/v5/he/heint"
 	"github.com/tuneinsight/lattigo/v5/mhe"
 	"github.com/tuneinsight/lattigo/v5/ring"
-	"github.com/tuneinsight/lattigo/v5/utils"
 	"github.com/tuneinsight/lattigo/v5/utils/sampling"
 )
 
@@ -215,7 +215,7 @@ func testEncToShares(tc *testContext, t *testing.T) {
 
 		tc.encoder.DecodeRingT(ptRt, ciphertext.Scale, values)
 
-		assert.True(t, utils.EqualSlice(coeffs, values))
+		assert.True(t, slices.Equal(coeffs, values))
 	})
 
 	crp := P[0].e2s.SampleCRP(params.MaxLevel(), tc.crs)
@@ -292,7 +292,7 @@ func testRefresh(tc *testContext, t *testing.T) {
 		require.True(t, ciphertext.Level() == maxLevel)
 		have := make([]uint64, tc.params.MaxSlots())
 		encoder.Decode(decryptorSk0.DecryptNew(ciphertext), have)
-		require.True(t, utils.EqualSlice(coeffs, have))
+		require.True(t, slices.Equal(coeffs, have))
 	})
 }
 
@@ -380,7 +380,7 @@ func testRefreshAndPermutation(tc *testContext, t *testing.T) {
 
 		//Decrypts and compares
 		require.True(t, ciphertext.Level() == maxLevel)
-		require.True(t, utils.EqualSlice(coeffsPermute, coeffsHave))
+		require.True(t, slices.Equal(coeffsPermute, coeffsHave))
 	})
 }
 
@@ -480,7 +480,7 @@ func testRefreshAndTransformSwitchParams(tc *testContext, t *testing.T) {
 
 		//Decrypts and compares
 		require.True(t, ciphertext.Level() == maxLevel)
-		require.True(t, utils.EqualSlice(coeffs, coeffsHave))
+		require.True(t, slices.Equal(coeffs, coeffsHave))
 	})
 }
 
@@ -508,5 +508,5 @@ func newTestVectors(tc *testContext, encryptor *rlwe.Encryptor, t *testing.T) (c
 func verifyTestVectors(tc *testContext, decryptor *rlwe.Decryptor, coeffs []uint64, ciphertext *rlwe.Ciphertext, t *testing.T) {
 	have := make([]uint64, tc.params.MaxSlots())
 	tc.encoder.Decode(decryptor.DecryptNew(ciphertext), have)
-	require.True(t, utils.EqualSlice(coeffs, have))
+	require.True(t, slices.Equal(coeffs, have))
 }

--- a/schemes/bfv/bfv_test.go
+++ b/schemes/bfv/bfv_test.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"math"
 	"runtime"
+	"slices"
 	"testing"
 
 	"github.com/tuneinsight/lattigo/v5/core/rlwe"
 	"github.com/tuneinsight/lattigo/v5/ring"
-	"github.com/tuneinsight/lattigo/v5/utils"
 	"github.com/tuneinsight/lattigo/v5/utils/sampling"
 
 	"github.com/stretchr/testify/require"
@@ -157,7 +157,7 @@ func verifyTestVectors(tc *testContext, decryptor *rlwe.Decryptor, coeffs ring.P
 		t.Fatal("invalid test object to verify")
 	}
 
-	require.True(t, utils.EqualSlice(coeffs.Coeffs[0], coeffsTest))
+	require.True(t, slices.Equal(coeffs.Coeffs[0], coeffsTest))
 }
 
 func testParameters(tc *testContext, t *testing.T) {
@@ -231,7 +231,7 @@ func testEncoder(tc *testContext, t *testing.T) {
 			tc.encoder.Encode(coeffsInt, plaintext)
 			have := make([]int64, tc.params.MaxSlots())
 			tc.encoder.Decode(plaintext, have)
-			require.True(t, utils.EqualSlice(coeffsInt, have))
+			require.True(t, slices.Equal(coeffsInt, have))
 		})
 	}
 }

--- a/schemes/bgv/bgv_test.go
+++ b/schemes/bgv/bgv_test.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"math"
 	"runtime"
+	"slices"
 	"testing"
 
 	"github.com/tuneinsight/lattigo/v5/core/rlwe"
 	"github.com/tuneinsight/lattigo/v5/ring"
-	"github.com/tuneinsight/lattigo/v5/utils"
 
 	"github.com/stretchr/testify/require"
 	"github.com/tuneinsight/lattigo/v5/utils/sampling"
@@ -168,7 +168,7 @@ func verifyTestVectors(tc *testContext, decryptor *rlwe.Decryptor, coeffs ring.P
 		t.Error("invalid test object to verify")
 	}
 
-	require.True(t, utils.EqualSlice(coeffs.Coeffs[0], coeffsTest))
+	require.True(t, slices.Equal(coeffs.Coeffs[0], coeffsTest))
 }
 
 func testParameters(tc *testContext, t *testing.T) {
@@ -243,7 +243,7 @@ func testEncoder(tc *testContext, t *testing.T) {
 			tc.encoder.Encode(coeffs, plaintext)
 			have := make([]int64, tc.params.MaxSlots())
 			tc.encoder.Decode(plaintext, have)
-			require.True(t, utils.EqualSlice(coeffs, have))
+			require.True(t, slices.Equal(coeffs, have))
 		})
 	}
 
@@ -261,7 +261,7 @@ func testEncoder(tc *testContext, t *testing.T) {
 			require.NoError(t, tc.encoder.Encode(coeffs, plaintext))
 			have := make([]uint64, tc.params.MaxSlots())
 			require.NoError(t, tc.encoder.Decode(plaintext, have))
-			require.True(t, utils.EqualSlice(coeffs, have))
+			require.True(t, slices.Equal(coeffs, have))
 		})
 	}
 
@@ -286,7 +286,7 @@ func testEncoder(tc *testContext, t *testing.T) {
 			require.NoError(t, tc.encoder.Encode(coeffs, plaintext))
 			have := make([]int64, tc.params.MaxSlots())
 			require.NoError(t, tc.encoder.Decode(plaintext, have))
-			require.True(t, utils.EqualSlice(coeffs, have))
+			require.True(t, slices.Equal(coeffs, have))
 		})
 	}
 }

--- a/schemes/bgv/params.go
+++ b/schemes/bgv/params.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"math/bits"
+	"slices"
 
 	"github.com/tuneinsight/lattigo/v5/core/rlwe"
 	"github.com/tuneinsight/lattigo/v5/ring"
@@ -82,7 +83,7 @@ func NewParameters(rlweParams rlwe.Parameters, t uint64) (p Parameters, err erro
 		return Parameters{}, fmt.Errorf("invalid parameters: t = 0")
 	}
 
-	if utils.IsInSlice(t, rlweParams.Q()) {
+	if slices.Contains(rlweParams.Q(), t) {
 		return Parameters{}, fmt.Errorf("insecure parameters: t|Q")
 	}
 

--- a/utils/slices.go
+++ b/utils/slices.go
@@ -20,25 +20,35 @@ func Alias2D[V any](x, y [][]V) bool {
 
 // EqualSlice checks the equality between two slices of comparables.
 func EqualSlice[V comparable](a, b []V) (v bool) {
-	v = true
-	for i := range a {
-		v = v && (a[i] == b[i])
+	if len(a) != len(b) {
+		return false
 	}
-	return
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // MaxSlice returns the maximum value in the slice.
 func MaxSlice[V constraints.Ordered](slice []V) (max V) {
-	for _, c := range slice {
-		max = Max(max, c)
+	if len(slice) != 0 {
+		max = slice[0]
+		for _, c := range slice {
+			max = Max(max, c)
+		}
 	}
 	return
 }
 
 // MinSlice returns the minimum value in the slice.
 func MinSlice[V constraints.Ordered](slice []V) (min V) {
-	for _, c := range slice {
-		min = Min(min, c)
+	if len(slice) != 0 {
+		min = slice[0]
+		for _, c := range slice {
+			min = Min(min, c)
+		}
 	}
 	return
 }
@@ -110,7 +120,7 @@ func RotateSlice[V any](s []V, k int) []V {
 func RotateSliceAllocFree[V any](s []V, k int, sout []V) {
 
 	if len(s) != len(sout) {
-		panic("cannot RotateUint64SliceAllocFree: s and sout of different lengths")
+		panic("cannot RotateSliceAllocFree: s and sout of different lengths")
 	}
 
 	if len(s) == 0 {

--- a/utils/slices.go
+++ b/utils/slices.go
@@ -18,49 +18,6 @@ func Alias2D[V any](x, y [][]V) bool {
 	return cap(x) > 0 && cap(y) > 0 && &x[0:cap(x)][cap(x)-1] == &y[0:cap(y)][cap(y)-1]
 }
 
-// EqualSlice checks the equality between two slices of comparables.
-func EqualSlice[V comparable](a, b []V) (v bool) {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
-// MaxSlice returns the maximum value in the slice.
-func MaxSlice[V constraints.Ordered](slice []V) (max V) {
-	if len(slice) != 0 {
-		max = slice[0]
-		for _, c := range slice {
-			max = Max(max, c)
-		}
-	}
-	return
-}
-
-// MinSlice returns the minimum value in the slice.
-func MinSlice[V constraints.Ordered](slice []V) (min V) {
-	if len(slice) != 0 {
-		min = slice[0]
-		for _, c := range slice {
-			min = Min(min, c)
-		}
-	}
-	return
-}
-
-// IsInSlice checks if x is in slice.
-func IsInSlice[V comparable](x V, slice []V) (v bool) {
-	for i := range slice {
-		v = v || (slice[i] == x)
-	}
-	return
-}
-
 // GetKeys returns the keys of the input map.
 // Order is not guaranteed.
 func GetKeys[K constraints.Ordered, V any](m map[K]V) (keys []K) {

--- a/utils/slices_test.go
+++ b/utils/slices_test.go
@@ -7,35 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMinSlice(t *testing.T) {
-	require.Equal(t, 1, MinSlice([]int{1, 2, 3, 4, 5}))
-	require.Equal(t, 0, MinSlice([]int{5, 4, 3, 2, 0}))
-	require.Equal(t, -1, MinSlice([]int{-1, 1}))
-	require.Equal(t, -2, MinSlice([]int{-1, -2}))
-}
-
-func TestMaxSlice(t *testing.T) {
-	require.Equal(t, 5, MaxSlice([]int{1, 2, 3, 4, 5}))
-	require.Equal(t, 5, MaxSlice([]int{5, 4, 3, 2, 0}))
-	require.Equal(t, 1, MaxSlice([]int{-1, 1}))
-	require.Equal(t, -1, MaxSlice([]int{-1, -2}))
-}
-
-func TestEqualSlice(t *testing.T) {
-	require.True(t, EqualSlice([]int{1, 2, 3}, []int{1, 2, 3}))
-	require.True(t, EqualSlice([]int{-1, -2, -3}, []int{-1, -2, -3}))
-	require.True(t, EqualSlice([]int{}, []int{}))
-	require.False(t, EqualSlice([]int{1, 2, 3, 4, 5}, []int{1, 2, 3, 4, 6}))
-	require.False(t, EqualSlice([]int{1, 2, 3, 4, 5}, []int{1, 2, 3, 4}))
-}
-
-func TestIsInSlice(t *testing.T) {
-	require.True(t, IsInSlice(1, []int{1, 2, 3, 4, 5}))
-	require.True(t, IsInSlice(-5, []int{-1, -2, -3, -4, -5}))
-	require.False(t, IsInSlice(0, []int{1, 2, 3, 4, 5}))
-	require.False(t, IsInSlice(6, []int{1, 2, 3, 4, 5}))
-}
-
 func TestGetSortedKeys(t *testing.T) {
 	m := map[int]int{1: 1, 3: 3, 2: 2}
 	require.Equal(t, []int{1, 2, 3}, GetSortedKeys(m))

--- a/utils/slices_test.go
+++ b/utils/slices_test.go
@@ -1,0 +1,95 @@
+package utils
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMinSlice(t *testing.T) {
+	require.Equal(t, 1, MinSlice([]int{1, 2, 3, 4, 5}))
+	require.Equal(t, 0, MinSlice([]int{5, 4, 3, 2, 0}))
+	require.Equal(t, -1, MinSlice([]int{-1, 1}))
+	require.Equal(t, -2, MinSlice([]int{-1, -2}))
+}
+
+func TestMaxSlice(t *testing.T) {
+	require.Equal(t, 5, MaxSlice([]int{1, 2, 3, 4, 5}))
+	require.Equal(t, 5, MaxSlice([]int{5, 4, 3, 2, 0}))
+	require.Equal(t, 1, MaxSlice([]int{-1, 1}))
+	require.Equal(t, -1, MaxSlice([]int{-1, -2}))
+}
+
+func TestEqualSlice(t *testing.T) {
+	require.True(t, EqualSlice([]int{1, 2, 3}, []int{1, 2, 3}))
+	require.True(t, EqualSlice([]int{-1, -2, -3}, []int{-1, -2, -3}))
+	require.True(t, EqualSlice([]int{}, []int{}))
+	require.False(t, EqualSlice([]int{1, 2, 3, 4, 5}, []int{1, 2, 3, 4, 6}))
+	require.False(t, EqualSlice([]int{1, 2, 3, 4, 5}, []int{1, 2, 3, 4}))
+}
+
+func TestIsInSlice(t *testing.T) {
+	require.True(t, IsInSlice(1, []int{1, 2, 3, 4, 5}))
+	require.True(t, IsInSlice(-5, []int{-1, -2, -3, -4, -5}))
+	require.False(t, IsInSlice(0, []int{1, 2, 3, 4, 5}))
+	require.False(t, IsInSlice(6, []int{1, 2, 3, 4, 5}))
+}
+
+func TestGetSortedKeys(t *testing.T) {
+	m := map[int]int{1: 1, 3: 3, 2: 2}
+	require.Equal(t, []int{1, 2, 3}, GetSortedKeys(m))
+	m = map[int]int{-1: 1, -3: 3, -2: 2}
+	require.Equal(t, []int{-3, -2, -1}, GetSortedKeys(m))
+}
+
+func TestGetDistincts(t *testing.T) {
+	actual := GetDistincts([]int{1, 2})
+	expected := []int{1, 2}
+	sort.Ints(expected)
+	sort.Ints(actual)
+	require.Equal(t, expected, actual)
+
+	actual = GetDistincts([]int{1, 2, 3, 1, 2, 3})
+	expected = []int{1, 2, 3}
+	sort.Ints(expected)
+	sort.Ints(actual)
+	require.Equal(t, expected, actual)
+
+	actual = GetDistincts([]int{-1, 1, 1, 1})
+	expected = []int{-1, 1}
+	sort.Ints(expected)
+	sort.Ints(actual)
+	require.Equal(t, expected, actual)
+}
+
+func TestRotateSlice(t *testing.T) {
+	actual := RotateSlice([]int{1, 2, 3, 4, 5}, 2)
+	expected := []int{3, 4, 5, 1, 2}
+	require.Equal(t, expected, actual)
+
+	actual = RotateSlice([]int{1, 2, 3, 4, 5}, -2)
+	expected = []int{4, 5, 1, 2, 3}
+	require.Equal(t, expected, actual)
+
+	actual = RotateSlice([]int{1, 2, 3, 4, 5}, 0)
+	expected = []int{1, 2, 3, 4, 5}
+	require.Equal(t, expected, actual)
+}
+
+func TestRotateSliceInPlace(t *testing.T) {
+	slice := []int{1, 2, 3, 4, 5}
+	RotateSliceInPlace(slice, 2)
+	expected := []int{3, 4, 5, 1, 2}
+	require.Equal(t, expected, slice)
+
+	slice = []int{1, 2, 3, 4, 5}
+	RotateSliceInPlace(slice, -2)
+	expected = []int{4, 5, 1, 2, 3}
+	require.Equal(t, expected, slice)
+
+	slice = []int{1, 2, 3, 4, 5}
+	RotateSliceInPlace(slice, 0)
+	expected = []int{1, 2, 3, 4, 5}
+	require.Equal(t, expected, slice)
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -35,7 +35,7 @@ func BitReverse64[V uint64 | uint32 | int | int64](index V, bitLen int) uint64 {
 	return bits.Reverse64(uint64(index)) >> (64 - bitLen)
 }
 
-// HammingWeight64 returns the hammingweight if the input value.
+// HammingWeight64 returns the hamming weight if the input value.
 func HammingWeight64[V uint64 | uint32 | int | int64](x V) V {
 	y := uint64(x)
 	y -= (y >> 1) & 0x5555555555555555


### PR DESCRIPTION
This PR bundles various bug fixes:

 - #457 (b326b02): Fix correctness errors in `utils.MaxSlice/MinSlice`. Prevent panic in `utils.EqualSlice` 
 - #459 (93154bd): Fix regression in `rlwe.Parameters` marshaller.
 - #466 (34a6325): Update reals tutorial explanation.
 - #458 / #471 (51451c4): Do not mix log/non-log primes in `rlwe.ParametersLiteral` initialisation.
 - #465 (454efab): Use decimal encoding to preserve `rlwe.Scale` to preserve binary size.
 - Bump minimum Go version to 1.21 with the use of `slices`
 
 - (25e88da): New bug reports policy.