### PR TITLE
Fix inner sum in BGV

### DIFF
--- a/schemes/bgv/params.go
+++ b/schemes/bgv/params.go
@@ -257,7 +257,7 @@ func (p Parameters) GaloisElementForRowRotation() uint64 {
 // InnerSum operation with parameters batch and n.
 func (p Parameters) GaloisElementsForInnerSum(batch, n int) (galEls []uint64) {
 	galEls = rlwe.GaloisElementsForInnerSum(p, batch, n)
-	if n > p.N()>>1 {
+	if n*batch > p.N()>>1 {
 		galEls = append(galEls, p.GaloisElementForRowRotation())
 	}
 	return


### PR DESCRIPTION
Fix #510 

### Issue 
`bgv.Evaluator.InnerSum` was not working properly when `n*batchSize > N/2` as `InnerSum` was acting separately on the "rows" of the underlying plaintext. 

### New behaviour
Let `l := n*batchSize`. 
- If `l <= n/2`: `bgv.Evaluator.InnerSum` acts as before (i.e. the inner sum is computed on both rows "independently").
- If `l = n`: the inner sum is computed over the `n` slots via a rotation of the rows and an addition as showcased in #510 
- Otherwise: return an error