### PR TITLE
CI: add Go v1.23 to the matrix of tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.22.2'
+        go-version: '1.23.5'
 
     - uses: actions/cache@v3
       with:
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.22.2', '1.21.9']
+        go: ['1.23.5', '1.22.11', '1.21.13']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,15 @@ jobs:
     name: Run static checks
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 1
     - name: Setup Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: '1.23.5'
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-tools-${{ hashFiles('**/go.sum') }}
@@ -35,14 +35,14 @@ jobs:
         go: ['1.23.5', '1.22.11', '1.21.13']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI Checks
 on:
   push:
+  pull_request:
+  workflow_dispatch:
 jobs:
   checks:
     name: Run static checks

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ checks: check_tools
 		false;\
     fi
 	
-	@STATICCHECKOUT=$$(staticcheck -go 1.22 -checks all ./...); \
+	@STATICCHECKOUT=$$(staticcheck -go 1.23 -checks all ./...); \
 	if [ -z "$$STATICCHECKOUT" ]; then\
         echo "staticcheck: OK";\
 	else \
@@ -78,7 +78,7 @@ EXECUTABLES = goimports staticcheck govulncheck gosec
 .PHONY: get_tools
 get_tools:
 	go install golang.org/x/tools/cmd/goimports@latest
-	go install honnef.co/go/tools/cmd/staticcheck@2023.1.7
+	go install honnef.co/go/tools/cmd/staticcheck@2024.1.1
 	go install golang.org/x/vuln/cmd/govulncheck@latest
 	go install github.com/securego/gosec/v2/cmd/gosec@latest
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Lattigo package organization is given in the Figure above.
                       subpackage includes test files that further demonstrate the use of Lattigo
                       primitives.
 
-- `lattigo/utils`: Generic utility methods. This package also contains the following sub-pacakges:
+- `lattigo/utils`: Generic utility methods. This package also contains the following sub-packages:
   - `bignum`: Arbitrary precision linear algebra and polynomial approximation.
   - `buffer`: Efficient methods to write/read on `io.Writer` and `io.Reader`.
   - `factorization`: Various factorization algorithms for medium-sized integers.


### PR DESCRIPTION
Maintenance PR to
- Add Go v1.23 to the tests in the CI
- Updates the versions of the GitHub actions (checkout, cache, go-setup)
- Updates the version of static checks and defaults to Go 1.23
- Add triggers for the CI to run on pull requests and workflow dispatch (allowing external contributors to run the CI on PRs)

Go v1.21 remains the minimum version defined in the `go.mod`.