### PR TITLE
CKKS encoder checks for IsNTT 

### DIFF
--- a/schemes/ckks/encoder.go
+++ b/schemes/ckks/encoder.go
@@ -164,7 +164,9 @@ func (ecd Encoder) Encode(values interface{}, pt *rlwe.Plaintext) (err error) {
 			return fmt.Errorf("cannot Encode: supported values.(type) for IsBatched=False is []float64 or []*big.Float, but %T was given", values)
 		}
 
-		ecd.parameters.RingQ().AtLevel(pt.Level()).NTT(pt.Value, pt.Value)
+		if pt.IsNTT {
+			ecd.parameters.RingQ().AtLevel(pt.Level()).NTT(pt.Value, pt.Value)
+		}
 	}
 
 	return


### PR DESCRIPTION
Fixes #501. The CKKS encoder checks the value of `pt.IsNTT` applies the NTT only if true. 