### PR TITLE
Thread-safe PRNG

### DIFF
--- a/core/rlwe/encryptor.go
+++ b/core/rlwe/encryptor.go
@@ -46,7 +46,6 @@ func NewEncryptor(params ParameterProvider, key EncryptionKey) *Encryptor {
 
 type Encryptor struct {
 	params Parameters
-	*encryptorBuffers
 
 	encKey         EncryptionKey
 	prng           sampling.PRNG
@@ -63,11 +62,7 @@ func (enc Encryptor) GetRLWEParameters() *Parameters {
 
 func newEncryptor(params Parameters) *Encryptor {
 
-	prng, err := sampling.NewPRNG()
-	if err != nil {
-		// Sanity check, this error should not happen.
-		panic(err)
-	}
+	prng := &sampling.ThreadSafePRNG{}
 
 	var bc *ring.BasisExtender
 	if params.PCount() != 0 {
@@ -89,13 +84,13 @@ func newEncryptor(params Parameters) *Encryptor {
 	}
 
 	return &Encryptor{
-		params:           params,
-		prng:             prng,
-		xeSampler:        xeSampler,
-		xsSampler:        xsSampler,
-		encryptorBuffers: newEncryptorBuffers(params),
-		uniformSampler:   ringqp.NewUniformSampler(prng, *params.RingQP()),
-		basisextender:    bc,
+		params:    params,
+		prng:      prng,
+		xeSampler: xeSampler,
+		xsSampler: xsSampler,
+		// encryptorBuffers: newEncryptorBuffers(params),
+		uniformSampler: ringqp.NewUniformSampler(prng, *params.RingQP()),
+		basisextender:  bc,
 	}
 }
 
@@ -122,19 +117,19 @@ func NewTestEncryptorWithPRNG(params ParameterProvider, key EncryptionKey, prng 
 	return enc
 }
 
-type encryptorBuffers struct {
-	buffQP [3]ringqp.Poly
-}
+// type encryptorBuffers struct {
+// 	buffQP [3]ringqp.Poly
+// }
 
-func newEncryptorBuffers(params Parameters) *encryptorBuffers {
-	return &encryptorBuffers{
-		buffQP: [3]ringqp.Poly{
-			params.RingQP().NewPoly(),
-			params.RingQP().NewPoly(),
-			params.RingQP().NewPoly(),
-		},
-	}
-}
+// func newEncryptorBuffers(params Parameters) *encryptorBuffers {
+// 	return &encryptorBuffers{
+// 		buffQP: [3]ringqp.Poly{
+// 			params.RingQP().NewPoly(),
+// 			params.RingQP().NewPoly(),
+// 			params.RingQP().NewPoly(),
+// 		},
+// 	}
+// }
 
 // Encrypt encrypts the input plaintext using the stored encryption key and writes the result on ct.
 // The method currently accepts only *[Ciphertext] as ct.
@@ -230,8 +225,9 @@ func (enc Encryptor) encryptZeroPk(pk *PublicKey, ct interface{}) (err error) {
 		levelQ = ct.Level()
 		levelP = 0
 
-		ct0QP = ringqp.Poly{Q: ct.Value[0], P: enc.buffQP[0].Q}
-		ct1QP = ringqp.Poly{Q: ct.Value[1], P: enc.buffQP[0].P}
+		tmpPolyQP := enc.params.RingQP().NewPoly()
+		ct0QP = ringqp.Poly{Q: ct.Value[0], P: tmpPolyQP.Q}
+		ct1QP = ringqp.Poly{Q: ct.Value[1], P: tmpPolyQP.P}
 	case Element[ringqp.Poly]:
 
 		levelQ = ct.LevelQ()
@@ -245,7 +241,7 @@ func (enc Encryptor) encryptZeroPk(pk *PublicKey, ct interface{}) (err error) {
 
 	ringQP := enc.params.RingQP().AtLevel(levelQ, levelP)
 
-	u := enc.buffQP[1]
+	u := enc.params.RingQP().NewPoly()
 
 	// We sample a RLWE instance (encryption of zero) over the extended ring (ciphertext ring + special prime)
 	enc.xsSampler.AtLevel(levelQ).Read(u.Q)
@@ -313,7 +309,7 @@ func (enc Encryptor) encryptZeroPkNoP(pk *PublicKey, ct Element[ring.Poly]) (err
 
 	ringQ := enc.params.RingQ().AtLevel(levelQ)
 
-	buffQ0 := enc.buffQP[0].Q
+	buffQ0 := enc.params.ringQ.NewPoly()
 
 	enc.xsSampler.AtLevel(levelQ).Read(buffQ0)
 	ringQ.NTT(buffQ0, buffQ0)
@@ -361,7 +357,7 @@ func (enc Encryptor) encryptZeroSk(sk *SecretKey, ct interface{}) (err error) {
 		if ct.Degree() == 1 {
 			c1 = ct.Value[1]
 		} else {
-			c1 = enc.buffQP[1].Q
+			c1 = enc.params.ringQ.NewPoly()
 		}
 
 		enc.uniformSampler.AtLevel(ct.Level(), -1).Read(ringqp.Poly{Q: c1})
@@ -379,7 +375,7 @@ func (enc Encryptor) encryptZeroSk(sk *SecretKey, ct interface{}) (err error) {
 		if ct.Degree() == 1 {
 			c1 = ct.Value[1]
 		} else {
-			c1 = enc.buffQP[1]
+			c1 = enc.params.RingQP().NewPoly()
 		}
 
 		// ct = (e, a)
@@ -407,7 +403,7 @@ func (enc Encryptor) encryptZeroSkFromC1(sk *SecretKey, ct Element[ring.Poly], c
 	ringQ.Neg(c0, c0)
 
 	if ct.IsNTT {
-		e := enc.buffQP[0].Q
+		e := ringQ.NewPoly()
 		enc.xeSampler.AtLevel(levelQ).Read(e)
 		ringQ.NTT(e, e)
 		ringQ.Add(c0, e, c0)
@@ -517,12 +513,12 @@ func (enc Encryptor) addPtToCt(level int, pt *Plaintext, ct *Ciphertext) {
 		if ct.IsNTT {
 			buff = pt.Value
 		} else {
-			buff = enc.buffQP[0].Q
+			buff = ringQ.NewPoly()
 			ringQ.NTT(pt.Value, buff)
 		}
 	} else {
 		if ct.IsNTT {
-			buff = enc.buffQP[0].Q
+			buff = ringQ.NewPoly()
 			ringQ.INTT(pt.Value, buff)
 		} else {
 			buff = pt.Value

--- a/core/rlwe/encryptor.go
+++ b/core/rlwe/encryptor.go
@@ -62,7 +62,10 @@ func (enc Encryptor) GetRLWEParameters() *Parameters {
 
 func newEncryptor(params Parameters) *Encryptor {
 
-	prng := &sampling.ThreadSafePRNG{}
+	prng, err := sampling.NewPRNG()
+	if err != nil {
+		panic(fmt.Errorf("newEncryptor: %w", err))
+	}
 
 	var bc *ring.BasisExtender
 	if params.PCount() != 0 {
@@ -84,11 +87,10 @@ func newEncryptor(params Parameters) *Encryptor {
 	}
 
 	return &Encryptor{
-		params:    params,
-		prng:      prng,
-		xeSampler: xeSampler,
-		xsSampler: xsSampler,
-		// encryptorBuffers: newEncryptorBuffers(params),
+		params:         params,
+		prng:           prng,
+		xeSampler:      xeSampler,
+		xsSampler:      xsSampler,
 		uniformSampler: ringqp.NewUniformSampler(prng, *params.RingQP()),
 		basisextender:  bc,
 	}
@@ -117,20 +119,6 @@ func newTestEncryptorWithKeyedPRNG(params ParameterProvider, key EncryptionKey, 
 
 	return enc
 }
-
-// type encryptorBuffers struct {
-// 	buffQP [3]ringqp.Poly
-// }
-
-// func newEncryptorBuffers(params Parameters) *encryptorBuffers {
-// 	return &encryptorBuffers{
-// 		buffQP: [3]ringqp.Poly{
-// 			params.RingQP().NewPoly(),
-// 			params.RingQP().NewPoly(),
-// 			params.RingQP().NewPoly(),
-// 		},
-// 	}
-// }
 
 // Encrypt encrypts the input plaintext using the stored encryption key and writes the result on ct.
 // The method currently accepts only *[Ciphertext] as ct.

--- a/core/rlwe/encryptor.go
+++ b/core/rlwe/encryptor.go
@@ -94,9 +94,10 @@ func newEncryptor(params Parameters) *Encryptor {
 	}
 }
 
-// NewTestEncryptorWithPRNG creates a new [Encryptor] that uses the provided prng for randomness.
+// newTestEncryptorWithKeyedPRNG creates a new [Encryptor] that uses the provided prng for randomness.
 // CAUTION: THIS FUNCTION SHOULD BE USED FOR TESTING PURPOSES ONLY.
-func NewTestEncryptorWithPRNG(params ParameterProvider, key EncryptionKey, prng sampling.PRNG) *Encryptor {
+// WARNING: The resulting encryptor is not meant to be used concurrently.
+func newTestEncryptorWithKeyedPRNG(params ParameterProvider, key EncryptionKey, prng *sampling.KeyedPRNG) *Encryptor {
 	p := *params.GetRLWEParameters()
 
 	enc := NewEncryptor(params, key)
@@ -455,10 +456,10 @@ func (enc Encryptor) encryptZeroSkFromC1QP(sk *SecretKey, ct Element[ringqp.Poly
 	return
 }
 
-// WithPRNG returns this encryptor with prng as its source of randomness for the uniform
+// withKeyedUniformSampling returns this encryptor with a keyed prng as its source of randomness for the uniform
 // element c1.
-// The returned encryptor isn't safe to use concurrently with the original encryptor.
-func (enc Encryptor) WithPRNG(prng sampling.PRNG) *Encryptor {
+// The returned encryptor is not thread safe (sampling will not be deterministic).
+func (enc Encryptor) withKeyedUniformSampling(prng *sampling.KeyedPRNG) *Encryptor {
 	enc.uniformSampler = ringqp.NewUniformSampler(prng, *enc.params.RingQP())
 	return &enc
 }

--- a/core/rlwe/keygenerator.go
+++ b/core/rlwe/keygenerator.go
@@ -253,7 +253,6 @@ func (kgen KeyGenerator) GenEvaluationKey(skInput, skOutput *SecretKey, evk *Eva
 
 	ringQ := kgen.params.RingQ()
 	ringP := kgen.params.RingP()
-	tmpPoly := ringQ.NewPoly()
 
 	buffSkOut := kgen.params.RingQP().NewPoly()
 	buffSkIn := kgen.params.RingQ().NewPoly()

--- a/core/rlwe/keygenerator.go
+++ b/core/rlwe/keygenerator.go
@@ -291,7 +291,7 @@ func (kgen KeyGenerator) genEvaluationKey(skIn ring.Poly, skOut ringqp.Poly, evk
 			panic(fmt.Errorf("sampling.NewKeyedPRNG: %w", err))
 		}
 
-		enc = enc.WithPRNG(sampler)
+		enc = enc.withKeyedUniformSampling(sampler)
 	}
 
 	// Samples an encryption of zero for each element of the EvaluationKey.

--- a/core/rlwe/rlwe_test.go
+++ b/core/rlwe/rlwe_test.go
@@ -318,7 +318,7 @@ func NewDeterministicTestContext(params Parameters, seedKeyGen, seedEnc []byte) 
 		panic(fmt.Errorf("NewDeterministicTestContext: failed to make prngEnc %w", err))
 	}
 	kgen := NewKeyGenerator(params)
-	kgenEncryptor := NewTestEncryptorWithPRNG(params, nil, prngKGen)
+	kgenEncryptor := newTestEncryptorWithKeyedPRNG(params, nil, prngKGen)
 	kgen.Encryptor = kgenEncryptor
 
 	sk := kgen.GenSecretKeyNew()
@@ -327,7 +327,7 @@ func NewDeterministicTestContext(params Parameters, seedKeyGen, seedEnc []byte) 
 
 	eval := NewEvaluator(params, nil)
 
-	enc := NewTestEncryptorWithPRNG(params, sk, prngEnc)
+	enc := newTestEncryptorWithKeyedPRNG(params, sk, prngEnc)
 
 	dec := NewDecryptor(params, sk)
 
@@ -653,7 +653,7 @@ func testEncryptor(tc *TestContext, level, bpw2 int, t *testing.T) {
 		prng1, _ := sampling.NewKeyedPRNG([]byte{'a', 'b', 'c'})
 		prng2, _ := sampling.NewKeyedPRNG([]byte{'a', 'b', 'c'})
 
-		enc.WithPRNG(prng1).Encrypt(pt, ct)
+		enc.withKeyedUniformSampling(prng1).Encrypt(pt, ct)
 
 		samplerQ := ring.NewUniformSampler(prng2, ringQ)
 

--- a/core/rlwe/rlwe_test.go
+++ b/core/rlwe/rlwe_test.go
@@ -39,6 +39,7 @@ func testString(params Parameters, levelQ, levelP, bpw2 int, opname string) stri
 // If such a modification is intended, this test must be updated and users notified s.t.
 // old serialized objects can be converted to the new format.
 func TestRLWEConstSerialization(t *testing.T) {
+	t.Skip()
 	// Note: changing nbIteration will change the expected value
 	const nbIteration = 10
 	const expected = "/mTt2kB+03NdOMoI1msW+glCZmrF1sxEGQkFsC6P1SA="
@@ -621,7 +622,6 @@ func testEncryptor(tc *TestContext, level, bpw2 int, t *testing.T) {
 		require.True(t, pkEnc1.params.Equal(&pkEnc2.params))
 		require.True(t, pkEnc1.encKey == pkEnc2.encKey)
 		require.False(t, (pkEnc1.basisextender == pkEnc2.basisextender) && (pkEnc1.basisextender != nil) && (pkEnc2.basisextender != nil))
-		require.False(t, pkEnc1.encryptorBuffers == pkEnc2.encryptorBuffers)
 		require.False(t, pkEnc1.xsSampler == pkEnc2.xsSampler)
 		require.False(t, pkEnc1.xeSampler == pkEnc2.xeSampler)
 	})
@@ -675,7 +675,6 @@ func testEncryptor(tc *TestContext, level, bpw2 int, t *testing.T) {
 		require.True(t, skEnc1.params.Equal(&skEnc2.params))
 		require.True(t, skEnc1.encKey == skEnc2.encKey)
 		require.False(t, (skEnc1.basisextender == skEnc2.basisextender) && (skEnc1.basisextender != nil) && (skEnc2.basisextender != nil))
-		require.False(t, skEnc1.encryptorBuffers == skEnc2.encryptorBuffers)
 		require.False(t, skEnc1.xsSampler == skEnc2.xsSampler)
 		require.False(t, skEnc1.xeSampler == skEnc2.xeSampler)
 	})
@@ -688,7 +687,6 @@ func testEncryptor(tc *TestContext, level, bpw2 int, t *testing.T) {
 		require.True(t, skEnc1.encKey == sk)
 		require.True(t, skEnc2.encKey == sk2)
 		require.True(t, skEnc1.basisextender == skEnc2.basisextender)
-		require.True(t, skEnc1.encryptorBuffers == skEnc2.encryptorBuffers)
 		require.True(t, skEnc1.xsSampler == skEnc2.xsSampler)
 		require.True(t, skEnc1.xeSampler == skEnc2.xeSampler)
 	})

--- a/core/rlwe/rlwe_test.go
+++ b/core/rlwe/rlwe_test.go
@@ -39,10 +39,9 @@ func testString(params Parameters, levelQ, levelP, bpw2 int, opname string) stri
 // If such a modification is intended, this test must be updated and users notified s.t.
 // old serialized objects can be converted to the new format.
 func TestRLWEConstSerialization(t *testing.T) {
-	t.Skip()
 	// Note: changing nbIteration will change the expected value
 	const nbIteration = 10
-	const expected = "/mTt2kB+03NdOMoI1msW+glCZmrF1sxEGQkFsC6P1SA="
+	const expected = "rlzKK0ti5MY4b2nJ9iPKFGHVoZI2w9Hr9doLdIreahM="
 	var err error
 	defaultParamsLiteral := testInsecure
 	seedKeyGen := []byte{'l', 'a', 't'}

--- a/core/rlwe/rlwe_test.go
+++ b/core/rlwe/rlwe_test.go
@@ -41,7 +41,7 @@ func testString(params Parameters, levelQ, levelP, bpw2 int, opname string) stri
 func TestRLWEConstSerialization(t *testing.T) {
 	// Note: changing nbIteration will change the expected value
 	const nbIteration = 10
-	const expected = "rlzKK0ti5MY4b2nJ9iPKFGHVoZI2w9Hr9doLdIreahM="
+	const expected = "1MTZP69YciXe+YjFnQbiUJIz7/d/h78atA/jaGKQhhc="
 	var err error
 	defaultParamsLiteral := testInsecure
 	seedKeyGen := []byte{'l', 'a', 't'}

--- a/ring/ringqp/samplers.go
+++ b/ring/ringqp/samplers.go
@@ -11,6 +11,7 @@ type UniformSampler struct {
 }
 
 // NewUniformSampler instantiates a new UniformSampler from a given PRNG.
+// WARNING: If the PRNG is deterministic/keyed (of type [sampling.KeyedPRNG]), *concurrent* calls to the sampler will not necessarily result in a deterministic output.
 func NewUniformSampler(prng sampling.PRNG, r Ring) (s UniformSampler) {
 	if r.RingQ != nil {
 		s.samplerQ = ring.NewUniformSampler(prng, r.RingQ)
@@ -66,12 +67,4 @@ func (s UniformSampler) ReadNew() (p Poly) {
 	}
 
 	return Poly{Q: Q, P: P}
-}
-
-func (s UniformSampler) WithPRNG(prng sampling.PRNG) UniformSampler {
-	sp := UniformSampler{samplerQ: s.samplerQ.WithPRNG(prng)}
-	if s.samplerP != nil {
-		sp.samplerP = s.samplerP.WithPRNG(prng)
-	}
-	return sp
 }

--- a/ring/sampler.go
+++ b/ring/sampler.go
@@ -61,6 +61,8 @@ type Ternary struct {
 // i.e., with coefficients uniformly distributed in the given ring.
 type Uniform struct{}
 
+// NewSampler returns a new sampler that follows the distribution given by DistributionParameters.
+// WARNING: If the PRNG is deterministic/keyed (of type [sampling.KeyedPRNG]), *concurrent* calls to the sampler will not necessarily result in a deterministic output.
 func NewSampler(prng sampling.PRNG, baseRing *Ring, X DistributionParameters, montgomery bool) (Sampler, error) {
 	switch X := X.(type) {
 	case DiscreteGaussian:

--- a/ring/sampler.go
+++ b/ring/sampler.go
@@ -79,17 +79,6 @@ type baseSampler struct {
 	baseRing *Ring
 }
 
-type randomBuffer struct {
-	randomBufferN []byte
-	ptr           int
-}
-
-func newRandomBuffer() *randomBuffer {
-	return &randomBuffer{
-		randomBufferN: make([]byte, 1024),
-	}
-}
-
 // AtLevel returns an instance of the target base sampler that operates at the target level.
 // This instance is not thread safe and cannot be used concurrently to the base instance.
 func (b baseSampler) AtLevel(level int) *baseSampler {

--- a/ring/sampler_gaussian.go
+++ b/ring/sampler_gaussian.go
@@ -72,7 +72,7 @@ func (g *GaussianSampler) read(pol Poly, f func(a, b, c uint64) uint64) {
 
 	r := g.baseRing
 
-	randomBufferN := make([]byte, 4*r.N())
+	randomBufferN := make([]byte, 1024)
 	var ptr int
 
 	level := r.level

--- a/ring/sampler_gaussian.go
+++ b/ring/sampler_gaussian.go
@@ -23,6 +23,7 @@ type GaussianSampler struct {
 // NewGaussianSampler creates a new instance of GaussianSampler from a PRNG, a ring definition and the truncated
 // Gaussian distribution parameters. Sigma is the desired standard deviation and bound is the maximum coefficient norm in absolute
 // value.
+// WARNING: If the PRNG is deterministic/keyed (of type [sampling.KeyedPRNG]), *concurrent* calls to the sampler will not necessarily result in a deterministic output.
 func NewGaussianSampler(prng sampling.PRNG, baseRing *Ring, X DiscreteGaussian, montgomery bool) (g *GaussianSampler) {
 	g = new(GaussianSampler)
 	g.baseSampler = &baseSampler{}

--- a/ring/sampler_ternary.go
+++ b/ring/sampler_ternary.go
@@ -22,6 +22,7 @@ type TernarySampler struct {
 
 // NewTernarySampler creates a new instance of TernarySampler from a PRNG, the ring definition and the distribution
 // parameters (see type Ternary). If "montgomery" is set to true, polynomials read from this sampler are in Montgomery form.
+// WARNING: If the PRNG is deterministic/keyed (of type [sampling.KeyedPRNG]), *concurrent* calls to the sampler will not necessarily result in a deterministic output.
 func NewTernarySampler(prng sampling.PRNG, baseRing *Ring, X Ternary, montgomery bool) (ts *TernarySampler, err error) {
 	ts = new(TernarySampler)
 	ts.baseSampler = &baseSampler{}

--- a/ring/sampler_uniform.go
+++ b/ring/sampler_uniform.go
@@ -12,6 +12,7 @@ type UniformSampler struct {
 }
 
 // NewUniformSampler creates a new instance of UniformSampler from a PRNG and ring definition.
+// WARNING: If the PRNG is deterministic/keyed (of type [sampling.KeyedPRNG]), *concurrent* calls to the sampler will not necessarily result in a deterministic output.
 func NewUniformSampler(prng sampling.PRNG, baseRing *Ring) (u *UniformSampler) {
 	u = new(UniformSampler)
 	u.baseSampler = &baseSampler{}
@@ -103,15 +104,6 @@ func (u *UniformSampler) ReadNew() (pol Poly) {
 	pol = u.baseRing.NewPoly()
 	u.Read(pol)
 	return
-}
-
-func (u *UniformSampler) WithPRNG(prng sampling.PRNG) *UniformSampler {
-	return &UniformSampler{
-		baseSampler: &baseSampler{
-			prng:     prng,
-			baseRing: u.baseRing,
-		},
-	}
 }
 
 // RandUniform samples a uniform randomInt variable in the range [0, mask] until randomInt is in the range [0, v-1].

--- a/utils/sampling/prng.go
+++ b/utils/sampling/prng.go
@@ -22,6 +22,18 @@ type KeyedPRNG struct {
 	xof blake2b.XOF
 }
 
+type ThreadSafePRNG struct {
+}
+
+// Read reads bytes from the KeyedPRNG on sum.
+func (prng *ThreadSafePRNG) Read(sum []byte) (n int, err error) {
+	tmpPRNG, err := NewPRNG()
+	if err != nil {
+		return 0, fmt.Errorf("crypto rand error: %w", err)
+	}
+	return tmpPRNG.Read(sum)
+}
+
 // NewKeyedPRNG creates a new instance of KeyedPRNG.
 // Accepts an optional key, else set key=nil which is treated as key=[]byte{}
 // WARNING: A PRNG INITIALISED WITH key=nil IS INSECURE!

--- a/utils/sampling/prng.go
+++ b/utils/sampling/prng.go
@@ -2,57 +2,49 @@ package sampling
 
 import (
 	"crypto/rand"
-	"fmt"
 	"io"
+	"sync"
 
 	"golang.org/x/crypto/blake2b"
 )
 
-// PRNG is an interface for secure (keyed) deterministic generation of random bytes
+// PRNG is an interface for secure generation of random bytes
 type PRNG interface {
 	io.Reader
-}
-
-// KeyedPRNG is a structure storing the parameters used to securely and deterministically generate shared
-// sequences of random bytes among different parties using the hash function blake2b. Backward sequence
-// security (given the digest i, compute the digest i-1) is ensured by default, however forward sequence
-// security (given the digest i, compute the digest i+1) is only ensured if the KeyedPRNG is keyed.
-type KeyedPRNG struct {
-	key []byte
-	xof blake2b.XOF
 }
 
 type ThreadSafePRNG struct {
 }
 
+// NewPRNG returns a new PRNG that is thread-safe
+func NewPRNG() (*ThreadSafePRNG, error) {
+	return &ThreadSafePRNG{}, nil
+}
+
 // Read reads bytes from the KeyedPRNG on sum.
 func (prng *ThreadSafePRNG) Read(sum []byte) (n int, err error) {
-	tmpPRNG, err := NewPRNG()
-	if err != nil {
-		return 0, fmt.Errorf("crypto rand error: %w", err)
-	}
-	return tmpPRNG.Read(sum)
+	return rand.Read(sum)
+}
+
+// KeyedPRNG is a structure storing the parameters used to securely and *deterministically* generate shared
+// sequences of random bytes among different parties using the hash function blake2b. Backward sequence
+// security (given the digest i, compute the digest i-1) is ensured by default, however forward sequence
+// security (given the digest i, compute the digest i+1) is only ensured if the KeyedPRNG is keyed.
+// WARNING: KeyedPRNG should NOT be called by multiple threads. It does not make sense to do so as the resulting
+// sequence will not be deterministic for a given key. For a PRNG securely seeded with a private keyuse [ThreadSafePRNG].
+type KeyedPRNG struct {
+	mutex sync.Mutex
+	key   []byte
+	xof   blake2b.XOF
 }
 
 // NewKeyedPRNG creates a new instance of KeyedPRNG.
 // Accepts an optional key, else set key=nil which is treated as key=[]byte{}
 // WARNING: A PRNG INITIALISED WITH key=nil IS INSECURE!
+// WARNING: KeyedPRNG should NOT be called by multiple threads. If that occurs, the generated sequence will not be deterministic.
 func NewKeyedPRNG(key []byte) (*KeyedPRNG, error) {
 	var err error
 	prng := new(KeyedPRNG)
-	prng.xof, err = blake2b.NewXOF(blake2b.OutputLengthUnknown, key)
-	return prng, err
-}
-
-// NewPRNG creates KeyedPRNG keyed from rand.Read for instances were no key should be provided by the user
-func NewPRNG() (*KeyedPRNG, error) {
-	var err error
-	prng := new(KeyedPRNG)
-	key := make([]byte, 64)
-	if _, err := rand.Read(key); err != nil {
-		return nil, fmt.Errorf("crypto rand error: %w", err)
-	}
-	prng.key = key
 	prng.xof, err = blake2b.NewXOF(blake2b.OutputLengthUnknown, key)
 	return prng, err
 }
@@ -67,11 +59,17 @@ func (prng *KeyedPRNG) Key() (key []byte) {
 }
 
 // Read reads bytes from the KeyedPRNG on sum.
+// WARNING: Read() should NOT be called concurrently by multiple threads. If that occurs, the generated sequence will not be deterministic.
 func (prng *KeyedPRNG) Read(sum []byte) (n int, err error) {
+	prng.mutex.Lock()
+	defer prng.mutex.Unlock()
 	return prng.xof.Read(sum)
 }
 
 // Reset resets the PRNG to its initial state.
+// WARNING: KeyedPRNG's methods should not be called concurrently. If that occurs, the generated sequence will not be deterministic.
 func (prng *KeyedPRNG) Reset() {
+	prng.mutex.Lock()
+	defer prng.mutex.Unlock()
 	prng.xof.Reset()
 }


### PR DESCRIPTION
Makes the PRNGs safe to use concurrently. 

- Common PRNG interface unchanged (must implement Read())
- Separate clearly the two types of PRNGs:
  - `ThreadSafePRNG`: meant for secret data generation, it simply a wrapper around `crypto/rand`. Use by default when `sampling.NewPRNG()` is called.
  - `KeyedPRNG`: used for deterministic (i.e. seeded) byte generation. Used for key compression and testing. 
- `KeyedPRNG` is now thread-safe in the sense that it won't crash when multiple threads access it and the generated data will be cryptographically random (given the seed is secure). **However, if it is called concurrently it will not generate a deterministic output.** In that sense, there is no use cases where calling `KeyedPRNG.Read()` concurrently makes sense.
- Limit as much as possible the visibility of methods using/generating `KeyedPRNG` and putting warning where it is unavoidable.

The PR also removes the buffers in the `encryptor`. The overhead is negligible and we don't want secrets lying around in the pool.    