### PR TITLE
BGV: allow encoding N values when using coefficient encoding

### DIFF
--- a/circuits/bgv/lintrans/lintrans_test.go
+++ b/circuits/bgv/lintrans/lintrans_test.go
@@ -65,7 +65,7 @@ func run(tc *bgv.TestContext, t *testing.T) {
 
 	t.Run("Evaluator/LinearTransformationBSGS=true/"+tc.String(), func(t *testing.T) {
 
-		values, _, ciphertext := bgv.NewTestVector(params, tc.Ecd, tc.Enc, params.MaxLevel(), params.DefaultScale())
+		values, _, ciphertext := bgv.NewTestVector(params, tc.Ecd, tc.Enc, params.MaxLevel(), params.DefaultScale(), true)
 
 		slots := ciphertext.Slots()
 
@@ -103,12 +103,12 @@ func run(tc *bgv.TestContext, t *testing.T) {
 
 		values = diagonals.Evaluate(values, newVec, add, muladd)
 
-		bgv.VerifyTestVectors(params, tc.Ecd, tc.Dec, ciphertext, values, t)
+		bgv.VerifyTestVectors(params, tc.Ecd, tc.Dec, ciphertext, values, true, t)
 	})
 
 	t.Run("Evaluator/LinearTransformationBSGS=false"+tc.String(), func(t *testing.T) {
 
-		values, _, ciphertext := bgv.NewTestVector(params, tc.Ecd, tc.Enc, params.MaxLevel(), params.DefaultScale())
+		values, _, ciphertext := bgv.NewTestVector(params, tc.Ecd, tc.Enc, params.MaxLevel(), params.DefaultScale(), true)
 
 		slots := ciphertext.Slots()
 
@@ -146,7 +146,7 @@ func run(tc *bgv.TestContext, t *testing.T) {
 
 		values = diagonals.Evaluate(values, newVec, add, muladd)
 
-		bgv.VerifyTestVectors(params, tc.Ecd, tc.Dec, ciphertext, values, t)
+		bgv.VerifyTestVectors(params, tc.Ecd, tc.Dec, ciphertext, values, true, t)
 	})
 
 	t.Run("Evaluator/LinearTransformation/Permutation"+tc.String(), func(t *testing.T) {
@@ -194,7 +194,7 @@ func run(tc *bgv.TestContext, t *testing.T) {
 
 		diagonals := Permutation[uint64](permutation).GetDiagonals(params.LogMaxSlots())
 
-		values, _, ciphertext := bgv.NewTestVector(params, tc.Ecd, tc.Enc, params.MaxLevel(), params.DefaultScale())
+		values, _, ciphertext := bgv.NewTestVector(params, tc.Ecd, tc.Enc, params.MaxLevel(), params.DefaultScale(), true)
 
 		ltparams := Parameters{
 			DiagonalsIndexList:        diagonals.DiagonalsIndexList(),
@@ -221,7 +221,7 @@ func run(tc *bgv.TestContext, t *testing.T) {
 
 		values = diagonals.Evaluate(values, newVec, add, muladd)
 
-		bgv.VerifyTestVectors(params, tc.Ecd, tc.Dec, ciphertext, values, t)
+		bgv.VerifyTestVectors(params, tc.Ecd, tc.Dec, ciphertext, values, true, t)
 	})
 }
 

--- a/circuits/bgv/polynomial/polynomial_evaluator_test.go
+++ b/circuits/bgv/polynomial/polynomial_evaluator_test.go
@@ -52,7 +52,7 @@ func run(tc *bgv.TestContext, t *testing.T) {
 			t.Skip("MaxLevel() to low")
 		}
 
-		values, _, ciphertext := bgv.NewTestVector(tc.Params, tc.Ecd, tc.Enc, tc.Params.MaxLevel(), tc.Params.DefaultScale())
+		values, _, ciphertext := bgv.NewTestVector(tc.Params, tc.Ecd, tc.Enc, tc.Params.MaxLevel(), tc.Params.DefaultScale(), true)
 
 		coeffs := []uint64{0, 0, 1}
 
@@ -72,7 +72,7 @@ func run(tc *bgv.TestContext, t *testing.T) {
 
 			require.Equal(t, res.Scale.Cmp(tc.Params.DefaultScale()), 0)
 
-			bgv.VerifyTestVectors(tc.Params, tc.Ecd, tc.Dec, res, values, t)
+			bgv.VerifyTestVectors(tc.Params, tc.Ecd, tc.Dec, res, values, true, t)
 		})
 
 		t.Run("Invariant"+tc.String(), func(t *testing.T) {
@@ -86,7 +86,7 @@ func run(tc *bgv.TestContext, t *testing.T) {
 			require.Equal(t, res.Level(), ciphertext.Level())
 			require.Equal(t, res.Scale.Cmp(tc.Params.DefaultScale()), 0)
 
-			bgv.VerifyTestVectors(tc.Params, tc.Ecd, tc.Dec, res, values, t)
+			bgv.VerifyTestVectors(tc.Params, tc.Ecd, tc.Dec, res, values, true, t)
 		})
 	})
 }

--- a/schemes/bgv/encoder.go
+++ b/schemes/bgv/encoder.go
@@ -137,8 +137,9 @@ func (ecd Encoder) GetRLWEParameters() *rlwe.Parameters {
 	return &ecd.parameters.Parameters
 }
 
-// Encode encodes an [IntegerSlice] of size at most N, where N is the smallest value satisfying PlaintextModulus = 1 mod 2N,
-// on a pre-allocated plaintext.
+// Encode encodes an [IntegerSlice] of size at most n on a pre-allocated plaintext,
+// where n is the largest value satisfying PlaintextModulus = 1 mod 2n if pt.IsBatched=true,
+// or the value of N set in the parameters otherwise.
 func (ecd Encoder) Encode(values interface{}, pt *rlwe.Plaintext) (err error) {
 
 	if pt.IsBatched {

--- a/schemes/bgv/params.go
+++ b/schemes/bgv/params.go
@@ -25,9 +25,9 @@ const (
 // the Q and P fields to the desired moduli chain, or by setting the LogQ and LogP fields to
 // the desired moduli sizes.
 //
-// Users must also specify the coefficient modulus in plaintext-space (T). This modulus must
-// be an NTT-friendly prime in the plaintext space: it must be equal to 1 modulo 2n where
-// n is the plaintext ring degree (i.e., the plaintext space has n slots).
+// Users must also specify the coefficient modulus in plaintext-space (T).
+// If slot encoding is used (default), the number of slots available in the plaintext will be equal to the largest n s.t. T = 1 mod 2n.
+// Otherwise, if coefficient encoding is used, the maximal number of slots available is equal to N.
 //
 // Optionally, users may specify the error variance (Sigma) and secrets' density (H). If left
 // unset, standard default values for these field are substituted at parameter creation (see


### PR DESCRIPTION
Fixes #478. 

Now, when a plaintext has its flag `isBatched=false`, one can encode a maximal number of N (set in the parameters) values onto it. This, regardless of the plaintext modulus set in the parameters. 

- [x] Makes the change described above
- [x] Modify BGV tests accordingly: test encoding with N values possible with `isBatched=false` and test other basic functions (add/sub) with unbatched ciphertexts
- [x] Make documentation more explicit about the maximal number of slots depending on the encoding.   