### PR TITLE
Bump go version 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25.6'
+        go-version: '1.25.9'
 
     - uses: actions/cache@v4
       with:
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.25", "1.24"]
+        go: ["1.26", "1.25"]
 
     steps:
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ checks: check_tools
 		false;\
 	fi
 
-	@GOSECOUT=$$(gosec -quiet ./...); \
+	@GOSECOUT=$$(gosec -quiet -exclude=G602 ./...); \
 	if [ -z "$$GOSECOUT" ]; then\
 		echo "gosec: OK";\
 	else \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tuneinsight/lattigo/v6
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
Bump go version in `go.mod` and in the CI. 
Disable G602 of gosec for now as it returns clear false positives (e.g. checking slice length is > n then addressing slice[n]). 